### PR TITLE
fix(ci): npm OIDC連携のためNPM_CONFIG_PROVENANCEを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,3 +40,4 @@ jobs:
           publish: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- リリースワークフローに `NPM_CONFIG_PROVENANCE: true` を追加
- npm OIDC認証を有効化し、`NPM_TOKEN` なしでパブリッシュ可能に

## 背景
`changesets/action` での npm パブリッシュ時に以下のエラーが発生:
- "Access token expired or revoked"
- E404 Not Found

`id-token: write` は設定済みだったが、`NPM_CONFIG_PROVENANCE` が未設定だったため OIDC 連携が機能していなかった。

## Test plan
- [ ] マージ後、リリースワークフローで npm パブリッシュが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)