### PR TITLE
fix(ci): npm v11.5.1以上にアップグレードしてOIDC対応

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- npm を v11.5.1 以上にアップグレードするステップを追加
- npm OIDC Trusted Publishing を有効化

## 背景
前回の修正（`NPM_CONFIG_PROVENANCE: true`）後もパブリッシュが失敗。
調査の結果、**npm OIDC Trusted Publishing には npm v11.5.1 以上が必要**と判明。

Node.js 22 にバンドルされている npm は 10.9.4 のため、明示的なアップグレードが必要。

## Test plan
- [ ] マージ後、リリースワークフローで npm パブリッシュが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)