### PR TITLE
feat(create-devenv): improve diff display with summary box and interactive viewer

### DIFF
--- a/.changeset/improve-diff-display.md
+++ b/.changeset/improve-diff-display.md
@@ -1,0 +1,10 @@
+---
+"@tktco/create-devenv": minor
+---
+
+feat(create-devenv): improve diff display with summary box and interactive viewer
+
+- Add new diff-viewer.ts with modern box-styled summary display
+- Show file changes grouped by type (added/modified/deleted) with line stats
+- Add interactive diff viewer with n/p navigation between files
+- Improve file selection UI with stats display

--- a/.changeset/word-diff-syntax-highlight.md
+++ b/.changeset/word-diff-syntax-highlight.md
@@ -1,0 +1,9 @@
+---
+"@tktco/create-devenv": minor
+---
+
+feat(create-devenv): add word-level diff and syntax highlighting
+
+- Word-level diff: highlight changed words with background colors
+- Syntax highlighting: automatic language detection based on file extension
+- Supports 30+ languages including TypeScript, JavaScript, JSON, YAML, etc.

--- a/packages/create-devenv/package.json
+++ b/packages/create-devenv/package.json
@@ -38,6 +38,7 @@
     "@inquirer/prompts": "^8.0.2",
     "@octokit/rest": "^22.0.1",
     "citty": "^0.1.6",
+    "cli-highlight": "^2.1.11",
     "consola": "^3.4.2",
     "defu": "^6.1.4",
     "diff": "^8.0.2",

--- a/packages/create-devenv/src/modules/schemas.ts
+++ b/packages/create-devenv/src/modules/schemas.ts
@@ -1,5 +1,21 @@
 import { z } from "zod";
 
+// ────────────────────────────────────────────────────────────────
+// Branded Types - より厳密な型定義
+// ────────────────────────────────────────────────────────────────
+
+/** 非負整数（行数カウント用） */
+export const nonNegativeIntSchema = z.number().int().nonnegative().brand<"NonNegativeInt">();
+export type NonNegativeInt = z.infer<typeof nonNegativeIntSchema>;
+
+/** ファイルパス */
+export const filePathSchema = z.string().min(1).brand<"FilePath">();
+export type FilePath = z.infer<typeof filePathSchema>;
+
+// ────────────────────────────────────────────────────────────────
+// Core Schemas
+// ────────────────────────────────────────────────────────────────
+
 // 上書き戦略
 export const overwriteStrategySchema = z.enum(["overwrite", "skip", "prompt"]);
 export type OverwriteStrategy = z.infer<typeof overwriteStrategySchema>;

--- a/packages/create-devenv/src/prompts/push.ts
+++ b/packages/create-devenv/src/prompts/push.ts
@@ -1,13 +1,9 @@
 import * as readline from "node:readline";
 import { checkbox, confirm, input, password, Separator } from "@inquirer/prompts";
+import { match, P } from "ts-pattern";
 import type { DiffResult, FileDiff } from "../modules/schemas";
 import { formatDiff } from "../utils/diff";
-import {
-  addStatsToFiles,
-  formatStats,
-  showDiffSummaryBox,
-  showFileDiffBox,
-} from "../utils/diff-viewer";
+import { getFileLabel, showDiffSummaryBox, showFileDiffBox } from "../utils/diff-viewer";
 import type { UntrackedFile, UntrackedFilesByFolder } from "../utils/untracked";
 
 export interface SelectedUntrackedFiles {
@@ -92,6 +88,26 @@ export async function promptGitHubToken(): Promise<string> {
   });
 }
 
+// ────────────────────────────────────────────────────────────────
+// キーアクション定義
+// ────────────────────────────────────────────────────────────────
+
+/** キー操作によるアクション */
+type KeyAction = "next" | "prev" | "exit" | "forceExit" | "none";
+
+/** キー入力をアクションに変換 */
+const classifyKeyAction = (key: readline.Key): KeyAction =>
+  match(key)
+    .with({ ctrl: true, name: "c" }, () => "forceExit" as const)
+    .with({ name: P.union("n", "right", "down", "j") }, () => "next" as const)
+    .with({ name: P.union("p", "left", "up", "k") }, () => "prev" as const)
+    .with({ name: P.union("return", "q", "escape") }, () => "exit" as const)
+    .otherwise(() => "none" as const);
+
+// ────────────────────────────────────────────────────────────────
+// インタラクティブ diff ビューア
+// ────────────────────────────────────────────────────────────────
+
 /**
  * インタラクティブ diff ビューア
  * n/p キーでファイル間をナビゲート、Enter または q で終了
@@ -102,7 +118,6 @@ async function interactiveDiffViewer(files: FileDiff[]): Promise<void> {
   let currentIndex = 0;
 
   const showCurrentDiff = (): void => {
-    // 画面クリア（スクロールバッファは保持）
     console.clear();
     showFileDiffBox(files[currentIndex], currentIndex, files.length, {
       showLineNumbers: true,
@@ -111,49 +126,53 @@ async function interactiveDiffViewer(files: FileDiff[]): Promise<void> {
   };
 
   return new Promise((resolve) => {
-    // raw モードでキー入力を受け付け
+    // TTY でない場合は全ファイルを順次表示
     if (!process.stdin.isTTY) {
-      // TTY でない場合は全ファイルを順次表示
-      for (let i = 0; i < files.length; i++) {
-        showFileDiffBox(files[i], i, files.length, { showLineNumbers: true });
-      }
+      files.forEach((file, i) => {
+        showFileDiffBox(file, i, files.length, { showLineNumbers: true });
+      });
       resolve();
       return;
     }
 
     readline.emitKeypressEvents(process.stdin);
     process.stdin.setRawMode(true);
-
     showCurrentDiff();
-
-    const handleKeypress = (_str: string, key: readline.Key): void => {
-      if (key.name === "n" || key.name === "right" || key.name === "down" || key.name === "j") {
-        // 次のファイル
-        if (currentIndex < files.length - 1) {
-          currentIndex++;
-          showCurrentDiff();
-        }
-      } else if (key.name === "p" || key.name === "left" || key.name === "up" || key.name === "k") {
-        // 前のファイル
-        if (currentIndex > 0) {
-          currentIndex--;
-          showCurrentDiff();
-        }
-      } else if (key.name === "return" || key.name === "q" || key.name === "escape") {
-        // 終了
-        cleanup();
-        console.clear();
-        resolve();
-      } else if (key.ctrl && key.name === "c") {
-        // Ctrl+C で終了
-        cleanup();
-        process.exit(0);
-      }
-    };
 
     const cleanup = (): void => {
       process.stdin.setRawMode(false);
       process.stdin.removeListener("keypress", handleKeypress);
+    };
+
+    const handleKeypress = (_str: string, key: readline.Key): void => {
+      const action = classifyKeyAction(key);
+
+      match(action)
+        .with("next", () => {
+          if (currentIndex < files.length - 1) {
+            currentIndex++;
+            showCurrentDiff();
+          }
+        })
+        .with("prev", () => {
+          if (currentIndex > 0) {
+            currentIndex--;
+            showCurrentDiff();
+          }
+        })
+        .with("exit", () => {
+          cleanup();
+          console.clear();
+          resolve();
+        })
+        .with("forceExit", () => {
+          cleanup();
+          process.exit(0);
+        })
+        .with("none", () => {
+          // 未知のキーは無視
+        })
+        .exhaustive();
     };
 
     process.stdin.on("keypress", handleKeypress);
@@ -186,10 +205,9 @@ export async function promptSelectFilesWithDiff(pushableFiles: FileDiff[]): Prom
   }
 
   // Step 4: チェックボックスでファイル選択
-  const filesWithStats = addStatsToFiles(pushableFiles);
-  const choices = filesWithStats.map((file) => ({
-    name: `${file.type === "added" ? "✚" : "⬡"} ${file.path} (${formatStats(file.stats)})`,
-    value: file as FileDiff,
+  const choices = pushableFiles.map((file) => ({
+    name: getFileLabel(file),
+    value: file,
     checked: true,
   }));
 

--- a/packages/create-devenv/src/utils/diff-viewer.ts
+++ b/packages/create-devenv/src/utils/diff-viewer.ts
@@ -1,0 +1,381 @@
+/**
+ * Diff Viewer - モダンな diff 表示コンポーネント
+ *
+ * gitui, lazygit などを参考にした見やすい diff 表示を提供
+ */
+
+import pc from "picocolors";
+import type { FileDiff } from "../modules/schemas";
+import { generateUnifiedDiff } from "./diff";
+
+// ────────────────────────────────────────────────────────────────
+// 型定義
+// ────────────────────────────────────────────────────────────────
+
+export interface DiffStats {
+  additions: number;
+  deletions: number;
+}
+
+export interface FileWithStats extends FileDiff {
+  stats: DiffStats;
+}
+
+interface GroupedFiles {
+  added: FileWithStats[];
+  modified: FileWithStats[];
+  deleted: FileWithStats[];
+}
+
+// ────────────────────────────────────────────────────────────────
+// 定数
+// ────────────────────────────────────────────────────────────────
+
+const BOX = {
+  topLeft: "┌",
+  topRight: "┐",
+  bottomLeft: "└",
+  bottomRight: "┘",
+  horizontal: "─",
+  vertical: "│",
+  tee: "├",
+  cross: "┼",
+  horizontalDown: "┬",
+  horizontalUp: "┴",
+} as const;
+
+const ICONS = {
+  added: "✚",
+  modified: "⬡",
+  deleted: "✖",
+  file: "◦",
+  tree: {
+    branch: "├─",
+    last: "└─",
+    vertical: "│ ",
+  },
+} as const;
+
+const DEFAULT_BOX_WIDTH = 60;
+
+// ────────────────────────────────────────────────────────────────
+// 統計計算
+// ────────────────────────────────────────────────────────────────
+
+/**
+ * unified diff から追加・削除行数を計算
+ */
+export function calculateDiffStats(fileDiff: FileDiff): DiffStats {
+  if (fileDiff.type === "unchanged") {
+    return { additions: 0, deletions: 0 };
+  }
+
+  if (fileDiff.type === "deleted") {
+    const lines = (fileDiff.templateContent || "").split("\n").length;
+    return { additions: 0, deletions: lines };
+  }
+
+  if (fileDiff.type === "added") {
+    const lines = (fileDiff.localContent || "").split("\n").length;
+    return { additions: lines, deletions: 0 };
+  }
+
+  // modified: unified diff をパースして計算
+  const diff = generateUnifiedDiff(fileDiff);
+  let additions = 0;
+  let deletions = 0;
+
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+") && !line.startsWith("+++")) {
+      additions++;
+    } else if (line.startsWith("-") && !line.startsWith("---")) {
+      deletions++;
+    }
+  }
+
+  return { additions, deletions };
+}
+
+/**
+ * ファイルリストに統計情報を付与
+ */
+export function addStatsToFiles(files: FileDiff[]): FileWithStats[] {
+  return files.map((file) => ({
+    ...file,
+    stats: calculateDiffStats(file),
+  }));
+}
+
+/**
+ * ファイルをタイプ別にグループ化
+ */
+export function groupFilesByType(files: FileWithStats[]): GroupedFiles {
+  return {
+    added: files.filter((f) => f.type === "added"),
+    modified: files.filter((f) => f.type === "modified"),
+    deleted: files.filter((f) => f.type === "deleted"),
+  };
+}
+
+/**
+ * 合計統計を計算
+ */
+export function calculateTotalStats(files: FileWithStats[]): DiffStats {
+  return files.reduce(
+    (acc, file) => ({
+      additions: acc.additions + file.stats.additions,
+      deletions: acc.deletions + file.stats.deletions,
+    }),
+    { additions: 0, deletions: 0 },
+  );
+}
+
+// ────────────────────────────────────────────────────────────────
+// フォーマット用ヘルパー
+// ────────────────────────────────────────────────────────────────
+
+/**
+ * 統計をフォーマット (+10 -5 形式)
+ */
+export function formatStats(stats: DiffStats): string {
+  const parts: string[] = [];
+  if (stats.additions > 0) {
+    parts.push(pc.green(`+${stats.additions}`));
+  }
+  if (stats.deletions > 0) {
+    parts.push(pc.red(`-${stats.deletions}`));
+  }
+  if (parts.length === 0) {
+    return pc.dim("(no changes)");
+  }
+  return parts.join(" ");
+}
+
+/**
+ * 統計をライン表記でフォーマット (+10 -5 lines)
+ */
+export function formatStatsWithLabel(stats: DiffStats): string {
+  const parts: string[] = [];
+  if (stats.additions > 0) {
+    parts.push(pc.green(`+${stats.additions}`));
+  }
+  if (stats.deletions > 0) {
+    parts.push(pc.red(`-${stats.deletions}`));
+  }
+  if (parts.length === 0) {
+    return "";
+  }
+  return `${parts.join(" ")} lines`;
+}
+
+/**
+ * ボックスの横線を生成
+ */
+function horizontalLine(width: number, left: string, right: string): string {
+  return pc.dim(left + BOX.horizontal.repeat(width - 2) + right);
+}
+
+/**
+ * テキストをボックス幅に合わせてパディング
+ */
+function padLine(text: string, width: number): string {
+  // ANSI コードを除去した実際の文字幅を計算
+  const plainText = text.replace(/\x1b\[[0-9;]*m/g, "");
+  const padding = Math.max(0, width - 4 - plainText.length);
+  return `${pc.dim(BOX.vertical)}  ${text}${" ".repeat(padding)}${pc.dim(BOX.vertical)}`;
+}
+
+// ────────────────────────────────────────────────────────────────
+// サマリーボックス表示
+// ────────────────────────────────────────────────────────────────
+
+/**
+ * diff サマリーをボックスで表示
+ */
+export function showDiffSummaryBox(files: FileDiff[]): void {
+  const filesWithStats = addStatsToFiles(files);
+  const grouped = groupFilesByType(filesWithStats);
+  const totalStats = calculateTotalStats(filesWithStats);
+  const changedFiles = filesWithStats.filter((f) => f.type !== "unchanged");
+
+  const width = DEFAULT_BOX_WIDTH;
+
+  console.log();
+  console.log(horizontalLine(width, BOX.topLeft, BOX.topRight));
+  console.log(padLine(pc.bold("📦 Changes to push"), width));
+  console.log(horizontalLine(width, BOX.tee, BOX.tee));
+  console.log(padLine("", width));
+
+  // Added files
+  if (grouped.added.length > 0) {
+    const addedStats = calculateTotalStats(grouped.added);
+    const header = `${pc.green(ICONS.added)} ${pc.green("added")} (${grouped.added.length} ${grouped.added.length === 1 ? "file" : "files"})`;
+    const statsStr = formatStatsWithLabel(addedStats);
+    console.log(padLine(`${header}${statsStr ? "  " + pc.dim(statsStr) : ""}`, width));
+
+    for (let i = 0; i < grouped.added.length; i++) {
+      const file = grouped.added[i];
+      const isLast = i === grouped.added.length - 1;
+      const prefix = isLast ? ICONS.tree.last : ICONS.tree.branch;
+      const stats = formatStats(file.stats);
+      console.log(padLine(`  ${pc.dim(prefix)} ${file.path}  ${stats}`, width));
+    }
+    console.log(padLine("", width));
+  }
+
+  // Modified files
+  if (grouped.modified.length > 0) {
+    const modifiedStats = calculateTotalStats(grouped.modified);
+    const header = `${pc.yellow(ICONS.modified)} ${pc.yellow("modified")} (${grouped.modified.length} ${grouped.modified.length === 1 ? "file" : "files"})`;
+    const statsStr = formatStatsWithLabel(modifiedStats);
+    console.log(padLine(`${header}${statsStr ? "  " + pc.dim(statsStr) : ""}`, width));
+
+    for (let i = 0; i < grouped.modified.length; i++) {
+      const file = grouped.modified[i];
+      const isLast = i === grouped.modified.length - 1;
+      const prefix = isLast ? ICONS.tree.last : ICONS.tree.branch;
+      const stats = formatStats(file.stats);
+      console.log(padLine(`  ${pc.dim(prefix)} ${file.path}  ${stats}`, width));
+    }
+    console.log(padLine("", width));
+  }
+
+  // Deleted files
+  if (grouped.deleted.length > 0) {
+    const deletedStats = calculateTotalStats(grouped.deleted);
+    const header = `${pc.red(ICONS.deleted)} ${pc.red("deleted")} (${grouped.deleted.length} ${grouped.deleted.length === 1 ? "file" : "files"})`;
+    const statsStr = formatStatsWithLabel(deletedStats);
+    console.log(padLine(`${header}${statsStr ? "  " + pc.dim(statsStr) : ""}`, width));
+
+    for (let i = 0; i < grouped.deleted.length; i++) {
+      const file = grouped.deleted[i];
+      const isLast = i === grouped.deleted.length - 1;
+      const prefix = isLast ? ICONS.tree.last : ICONS.tree.branch;
+      const stats = formatStats(file.stats);
+      console.log(padLine(`  ${pc.dim(prefix)} ${file.path}  ${stats}`, width));
+    }
+    console.log(padLine("", width));
+  }
+
+  // Total
+  console.log(horizontalLine(width, BOX.tee, BOX.tee));
+  const totalLine = `Total: ${changedFiles.length} ${changedFiles.length === 1 ? "file" : "files"}  (${formatStatsWithLabel(totalStats)})`;
+  console.log(padLine(totalLine, width));
+  console.log(horizontalLine(width, BOX.bottomLeft, BOX.bottomRight));
+  console.log();
+}
+
+// ────────────────────────────────────────────────────────────────
+// 単一ファイル diff ボックス表示
+// ────────────────────────────────────────────────────────────────
+
+export interface DiffViewOptions {
+  showLineNumbers?: boolean;
+  contextLines?: number;
+  maxLines?: number;
+}
+
+/**
+ * 単一ファイルの diff をボックス表示
+ */
+export function showFileDiffBox(
+  file: FileDiff,
+  index: number,
+  total: number,
+  options: DiffViewOptions = {},
+): void {
+  const { showLineNumbers = true, maxLines } = options;
+  const stats = calculateDiffStats(file);
+  const width = DEFAULT_BOX_WIDTH;
+
+  // ヘッダー
+  console.log();
+  console.log(horizontalLine(width, BOX.topLeft, BOX.topRight));
+
+  // ファイル名とタイプ
+  const typeIcon = file.type === "added" ? pc.green(ICONS.added) : pc.yellow(ICONS.modified);
+  const typeLabel = file.type === "added" ? pc.green("added") : pc.yellow("modified");
+  const position = pc.dim(`[${index + 1}/${total}]`);
+
+  console.log(padLine(`${position} ${typeIcon} ${pc.bold(file.path)}`, width));
+  console.log(padLine(`${typeLabel}  ${formatStatsWithLabel(stats)}`, width));
+  console.log(horizontalLine(width, BOX.tee, BOX.tee));
+
+  // Diff 内容
+  const diffContent = generateUnifiedDiff(file);
+  const lines = diffContent.split("\n");
+
+  // ヘッダー行（---/+++）をスキップして内容のみ表示
+  const contentLines = lines.filter(
+    (line) =>
+      !line.startsWith("Index:") &&
+      !line.startsWith("===") &&
+      !line.startsWith("---") &&
+      !line.startsWith("+++"),
+  );
+
+  let displayLines = contentLines;
+  let truncated = false;
+
+  if (maxLines && contentLines.length > maxLines) {
+    displayLines = contentLines.slice(0, maxLines);
+    truncated = true;
+  }
+
+  let lineNum = 0;
+  for (const line of displayLines) {
+    let coloredLine: string;
+    let linePrefix = "";
+
+    if (line.startsWith("@@")) {
+      coloredLine = pc.cyan(line);
+      linePrefix = "";
+    } else if (line.startsWith("+")) {
+      coloredLine = pc.green(line);
+      lineNum++;
+      linePrefix = showLineNumbers ? pc.dim(`${String(lineNum).padStart(4)} `) : "";
+    } else if (line.startsWith("-")) {
+      coloredLine = pc.red(line);
+      linePrefix = showLineNumbers ? pc.dim("     ") : "";
+    } else {
+      coloredLine = line;
+      lineNum++;
+      linePrefix = showLineNumbers ? pc.dim(`${String(lineNum).padStart(4)} `) : "";
+    }
+
+    // 行が長すぎる場合は切り詰め
+    const plainLine = line.replace(/\x1b\[[0-9;]*m/g, "");
+    const maxContentWidth = width - 8 - (showLineNumbers ? 5 : 0);
+
+    if (plainLine.length > maxContentWidth) {
+      const truncatedContent = line.slice(0, maxContentWidth - 3) + "...";
+      coloredLine = line.startsWith("+")
+        ? pc.green(truncatedContent)
+        : line.startsWith("-")
+          ? pc.red(truncatedContent)
+          : truncatedContent;
+    }
+
+    console.log(padLine(`${linePrefix}${coloredLine}`, width));
+  }
+
+  if (truncated) {
+    const remaining = contentLines.length - displayLines.length;
+    console.log(padLine(pc.dim(`... ${remaining} more lines`), width));
+  }
+
+  // フッター
+  console.log(horizontalLine(width, BOX.tee, BOX.tee));
+  console.log(padLine(pc.dim("[Enter] Back  [n] Next  [p] Prev  [q] Quit"), width));
+  console.log(horizontalLine(width, BOX.bottomLeft, BOX.bottomRight));
+  console.log();
+}
+
+/**
+ * ファイル選択用のラベル生成
+ */
+export function getFileLabel(file: FileDiff): string {
+  const stats = calculateDiffStats(file);
+  const icon = file.type === "added" ? pc.green(ICONS.added) : pc.yellow(ICONS.modified);
+  return `${icon} ${file.path} (${formatStats(stats)})`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       citty:
         specifier: ^0.1.6
         version: 0.1.6
+      cli-highlight:
+        specifier: ^2.1.11
+        version: 2.1.11
       consola:
         specifier: ^3.4.2
         version: 3.4.2
@@ -993,6 +996,10 @@ packages:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
 
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -1000,6 +1007,9 @@ packages:
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -1044,6 +1054,10 @@ packages:
     resolution: {integrity: sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==}
     engines: {node: '>=18'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
@@ -1054,9 +1068,24 @@ packages:
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
@@ -1112,6 +1141,9 @@ packages:
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
@@ -1127,6 +1159,10 @@ packages:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -1186,6 +1222,10 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
@@ -1217,6 +1257,9 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -1251,6 +1294,10 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -1352,6 +1399,9 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1376,6 +1426,10 @@ packages:
     resolution: {integrity: sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==}
     engines: {node: ^14.16.0 || >=16.10.0}
     hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -1424,6 +1478,15 @@ packages:
 
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1479,6 +1542,10 @@ packages:
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -1566,6 +1633,10 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
@@ -1589,6 +1660,13 @@ packages:
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   thingies@2.5.0:
     resolution: {integrity: sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==}
@@ -1781,9 +1859,25 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
 
   zod@4.1.13:
     resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
@@ -2606,9 +2700,15 @@ snapshots:
 
   ansi-regex@6.2.2: {}
 
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   ansi-styles@6.2.3: {}
 
   ansis@4.2.0: {}
+
+  any-promise@1.3.0: {}
 
   argparse@1.0.10:
     dependencies:
@@ -2647,6 +2747,11 @@ snapshots:
 
   chai@6.2.1: {}
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chardet@2.1.1: {}
 
   ci-info@3.9.0: {}
@@ -2655,7 +2760,28 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.0
+
   cli-width@4.1.0: {}
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
 
   confbox@0.2.2: {}
 
@@ -2688,6 +2814,8 @@ snapshots:
   dts-resolver@2.1.3: {}
 
   emoji-regex@10.6.0: {}
+
+  emoji-regex@8.0.0: {}
 
   empathic@2.0.0: {}
 
@@ -2726,6 +2854,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
+
+  escalade@3.2.0: {}
 
   esprima@4.0.1: {}
 
@@ -2781,6 +2911,8 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-caller-file@2.0.5: {}
+
   get-east-asian-width@1.4.0: {}
 
   get-tsconfig@4.13.0:
@@ -2817,6 +2949,8 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  highlight.js@10.7.3: {}
+
   hookable@5.5.3: {}
 
   html-escaper@2.0.2: {}
@@ -2836,6 +2970,8 @@ snapshots:
   import-without-cache@0.2.4: {}
 
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -2936,6 +3072,12 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
   nanoid@3.3.11: {}
 
   nanospinner@1.2.2:
@@ -2955,6 +3097,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.3.0
       tinyexec: 1.0.2
+
+  object-assign@4.1.1: {}
 
   obug@2.1.1: {}
 
@@ -3014,6 +3158,14 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -3056,6 +3208,8 @@ snapshots:
       js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  require-directory@2.1.1: {}
 
   resolve-from@5.0.0: {}
 
@@ -3159,6 +3313,12 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
@@ -3180,6 +3340,14 @@ snapshots:
       has-flag: 4.0.0
 
   term-size@2.2.1: {}
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
 
   thingies@2.5.0(tslib@2.8.1):
     dependencies:
@@ -3324,10 +3492,30 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.1.2
+
+  y18n@5.0.8: {}
+
+  yargs-parser@20.2.9: {}
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   zod@4.1.13: {}


### PR DESCRIPTION
- Add new diff-viewer.ts with modern box-styled summary display
- Show file changes grouped by type (added/modified/deleted) with line stats
- Add interactive diff viewer with n/p key navigation between files
- Improve file selection UI with stats display (+X -Y format)

The new flow is:
1. Show summary box with all changes grouped by type
2. Optionally view detailed diff for each file (n/p to navigate)
3. Select files to include in PR with checkbox