### PR TITLE
test(create-devenv): expand test coverage significantly

### DIFF
--- a/.changeset/quiet-files-talk.md
+++ b/.changeset/quiet-files-talk.md
@@ -1,0 +1,17 @@
+---
+"@tktco/create-devenv": patch
+---
+
+テストを大幅に拡充
+
+- config.ts: 設定ファイルの読み書きテスト
+- patterns.ts: パターンマッチングとマージのテスト
+- modules/schemas.ts: Zod スキーマバリデーションテスト
+- modules/loader.ts: modules.jsonc ローダーテスト
+- modules/index.ts: モジュールヘルパー関数テスト
+- untracked.ts: 未追跡ファイル検出テスト
+- readme.ts: README 生成テスト
+- diff-viewer.ts: 差分表示テスト
+- github.ts: GitHub API 連携テスト
+
+テスト数: 40 → 209 (+169 テスト)

--- a/packages/create-devenv/src/modules/__tests__/index.test.ts
+++ b/packages/create-devenv/src/modules/__tests__/index.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import {
+  defaultModules,
+  getAllPatterns,
+  getModuleById,
+  getPatternsByModuleIds,
+  modules,
+} from "../index";
+
+describe("defaultModules", () => {
+  it("定義されたモジュールを持つ", () => {
+    expect(defaultModules.length).toBeGreaterThan(0);
+  });
+
+  it("ルートモジュール (.) を含む", () => {
+    const rootModule = defaultModules.find((m) => m.id === ".");
+    expect(rootModule).toBeDefined();
+    expect(rootModule?.name).toBe("ルート設定");
+  });
+
+  it(".devcontainer モジュールを含む", () => {
+    const devcontainerModule = defaultModules.find((m) => m.id === ".devcontainer");
+    expect(devcontainerModule).toBeDefined();
+    expect(devcontainerModule?.patterns.length).toBeGreaterThan(0);
+  });
+
+  it(".github モジュールを含む", () => {
+    const githubModule = defaultModules.find((m) => m.id === ".github");
+    expect(githubModule).toBeDefined();
+  });
+
+  it(".claude モジュールを含む", () => {
+    const claudeModule = defaultModules.find((m) => m.id === ".claude");
+    expect(claudeModule).toBeDefined();
+  });
+
+  it("全モジュールが必須フィールドを持つ", () => {
+    for (const mod of defaultModules) {
+      expect(mod.id).toBeDefined();
+      expect(mod.name).toBeDefined();
+      expect(mod.description).toBeDefined();
+      expect(mod.patterns).toBeDefined();
+      expect(Array.isArray(mod.patterns)).toBe(true);
+    }
+  });
+});
+
+describe("modules (alias)", () => {
+  it("defaultModules と同じ参照を持つ", () => {
+    expect(modules).toBe(defaultModules);
+  });
+});
+
+describe("getModuleById", () => {
+  it("ID でデフォルトモジュールを取得できる", () => {
+    const result = getModuleById(".");
+    expect(result?.id).toBe(".");
+    expect(result?.name).toBe("ルート設定");
+  });
+
+  it("存在しない ID の場合は undefined を返す", () => {
+    const result = getModuleById("nonexistent");
+    expect(result).toBeUndefined();
+  });
+
+  it("カスタムモジュールリストから取得できる", () => {
+    const customModules = [
+      { id: "custom", name: "Custom", description: "Custom module", patterns: ["*.custom"] },
+    ];
+
+    const result = getModuleById("custom", customModules);
+    expect(result?.id).toBe("custom");
+  });
+
+  it("カスタムリストに存在しない場合は undefined を返す", () => {
+    const customModules = [
+      { id: "custom", name: "Custom", description: "Custom module", patterns: [] },
+    ];
+
+    const result = getModuleById(".", customModules);
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("getAllPatterns", () => {
+  it("デフォルトモジュールの全パターンを取得する", () => {
+    const patterns = getAllPatterns();
+
+    expect(patterns.length).toBeGreaterThan(0);
+    // デフォルトモジュールのパターンが含まれていることを確認
+    expect(patterns).toContain(".mcp.json");
+  });
+
+  it("カスタムモジュールリストからパターンを取得できる", () => {
+    const customModules = [
+      { id: "a", name: "A", description: "A", patterns: ["a.txt", "a.json"] },
+      { id: "b", name: "B", description: "B", patterns: ["b.txt"] },
+    ];
+
+    const patterns = getAllPatterns(customModules);
+
+    expect(patterns).toEqual(["a.txt", "a.json", "b.txt"]);
+  });
+
+  it("空のモジュールリストの場合は空配列を返す", () => {
+    const patterns = getAllPatterns([]);
+    expect(patterns).toEqual([]);
+  });
+
+  it("パターンのないモジュールを含む場合も動作する", () => {
+    const customModules = [
+      { id: "a", name: "A", description: "A", patterns: ["a.txt"] },
+      { id: "b", name: "B", description: "B", patterns: [] },
+    ];
+
+    const patterns = getAllPatterns(customModules);
+
+    expect(patterns).toEqual(["a.txt"]);
+  });
+});
+
+describe("getPatternsByModuleIds", () => {
+  it("指定したモジュール ID のパターンのみを返す", () => {
+    const customModules = [
+      { id: "a", name: "A", description: "A", patterns: ["a.txt"] },
+      { id: "b", name: "B", description: "B", patterns: ["b.txt"] },
+      { id: "c", name: "C", description: "C", patterns: ["c.txt"] },
+    ];
+
+    const patterns = getPatternsByModuleIds(["a", "c"], customModules);
+
+    expect(patterns).toEqual(["a.txt", "c.txt"]);
+  });
+
+  it("デフォルトモジュールから取得できる", () => {
+    const patterns = getPatternsByModuleIds(["."]);
+
+    expect(patterns).toContain(".mcp.json");
+    expect(patterns).toContain(".mise.toml");
+  });
+
+  it("存在しないモジュール ID は無視する", () => {
+    const customModules = [
+      { id: "a", name: "A", description: "A", patterns: ["a.txt"] },
+      { id: "b", name: "B", description: "B", patterns: ["b.txt"] },
+    ];
+
+    const patterns = getPatternsByModuleIds(["a", "nonexistent"], customModules);
+
+    expect(patterns).toEqual(["a.txt"]);
+  });
+
+  it("空のモジュール ID リストの場合は空配列を返す", () => {
+    const patterns = getPatternsByModuleIds([]);
+    expect(patterns).toEqual([]);
+  });
+
+  it("全モジュール ID を指定すると全パターンを返す", () => {
+    const customModules = [
+      { id: "a", name: "A", description: "A", patterns: ["a.txt"] },
+      { id: "b", name: "B", description: "B", patterns: ["b.txt"] },
+    ];
+
+    const patterns = getPatternsByModuleIds(["a", "b"], customModules);
+
+    expect(patterns).toEqual(["a.txt", "b.txt"]);
+  });
+});

--- a/packages/create-devenv/src/modules/__tests__/loader.test.ts
+++ b/packages/create-devenv/src/modules/__tests__/loader.test.ts
@@ -1,0 +1,338 @@
+import { vol } from "memfs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// fs モジュールをモック
+vi.mock("node:fs", async () => {
+  const memfs = await import("memfs");
+  return memfs.fs;
+});
+
+vi.mock("node:fs/promises", async () => {
+  const memfs = await import("memfs");
+  return memfs.fs.promises;
+});
+
+// モック後にインポート
+const {
+  loadModulesFile,
+  getModuleByIdFromList,
+  addPatternToModulesFile,
+  saveModulesFile,
+  getModulesFilePath,
+  modulesFileExists,
+} = await import("../loader");
+
+describe("loadModulesFile", () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it("正常な modules.jsonc を読み込める", async () => {
+    const modulesContent = JSON.stringify({
+      modules: [
+        {
+          id: ".devcontainer",
+          name: "DevContainer",
+          description: "VS Code DevContainer 設定",
+          patterns: [".devcontainer/**"],
+        },
+      ],
+    });
+
+    vol.fromJSON({
+      "/project/.devenv/modules.jsonc": modulesContent,
+    });
+
+    const result = await loadModulesFile("/project");
+
+    expect(result.modules).toHaveLength(1);
+    expect(result.modules[0].id).toBe(".devcontainer");
+    expect(result.rawContent).toBe(modulesContent);
+  });
+
+  it("JSONC コメント付きファイルを読み込める", async () => {
+    const modulesContent = `{
+      // これはコメント
+      "modules": [
+        {
+          "id": ".github",
+          "name": "GitHub",
+          "description": "GitHub 設定",
+          /* 複数行コメント */
+          "patterns": [".github/**"]
+        }
+      ]
+    }`;
+
+    vol.fromJSON({
+      "/project/.devenv/modules.jsonc": modulesContent,
+    });
+
+    const result = await loadModulesFile("/project");
+
+    expect(result.modules).toHaveLength(1);
+    expect(result.modules[0].id).toBe(".github");
+  });
+
+  it("$schema フィールドを無視して読み込める", async () => {
+    const modulesContent = JSON.stringify({
+      $schema: "https://example.com/schema.json",
+      modules: [
+        {
+          id: ".",
+          name: "Root",
+          description: "ルート設定",
+          patterns: [".mcp.json"],
+        },
+      ],
+    });
+
+    vol.fromJSON({
+      "/project/.devenv/modules.jsonc": modulesContent,
+    });
+
+    const result = await loadModulesFile("/project");
+
+    expect(result.modules).toHaveLength(1);
+  });
+
+  it("ファイルが存在しない場合はエラー", async () => {
+    vol.fromJSON({});
+
+    await expect(loadModulesFile("/project")).rejects.toThrow(
+      ".devenv/modules.jsonc が見つかりません",
+    );
+  });
+
+  it("不正な JSON の場合はエラー", async () => {
+    vol.fromJSON({
+      "/project/.devenv/modules.jsonc": "{ invalid json }",
+    });
+
+    await expect(loadModulesFile("/project")).rejects.toThrow();
+  });
+
+  it("スキーマに合わない場合はエラー", async () => {
+    vol.fromJSON({
+      "/project/.devenv/modules.jsonc": JSON.stringify({
+        modules: [
+          {
+            id: ".devcontainer",
+            // name が欠けている
+            description: "Test",
+            patterns: [],
+          },
+        ],
+      }),
+    });
+
+    await expect(loadModulesFile("/project")).rejects.toThrow();
+  });
+
+  it("setupDescription を含むモジュールを読み込める", async () => {
+    const modulesContent = JSON.stringify({
+      modules: [
+        {
+          id: ".devcontainer",
+          name: "DevContainer",
+          description: "VS Code DevContainer 設定",
+          setupDescription: "VS Code で開くとセットアップされます",
+          patterns: [".devcontainer/**"],
+        },
+      ],
+    });
+
+    vol.fromJSON({
+      "/project/.devenv/modules.jsonc": modulesContent,
+    });
+
+    const result = await loadModulesFile("/project");
+
+    expect(result.modules[0].setupDescription).toBe("VS Code で開くとセットアップされます");
+  });
+});
+
+describe("getModuleByIdFromList", () => {
+  const modules = [
+    { id: ".devcontainer", name: "DevContainer", description: "Test", patterns: [] },
+    { id: ".github", name: "GitHub", description: "Test", patterns: [] },
+  ];
+
+  it("ID でモジュールを取得できる", () => {
+    const result = getModuleByIdFromList(modules, ".devcontainer");
+
+    expect(result?.id).toBe(".devcontainer");
+    expect(result?.name).toBe("DevContainer");
+  });
+
+  it("存在しない ID の場合は undefined を返す", () => {
+    const result = getModuleByIdFromList(modules, ".claude");
+
+    expect(result).toBeUndefined();
+  });
+
+  it("空のリストの場合は undefined を返す", () => {
+    const result = getModuleByIdFromList([], ".devcontainer");
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("addPatternToModulesFile", () => {
+  it("既存モジュールにパターンを追加できる", () => {
+    const rawContent = JSON.stringify(
+      {
+        modules: [
+          {
+            id: ".devcontainer",
+            name: "DevContainer",
+            description: "Test",
+            patterns: [".devcontainer/devcontainer.json"],
+          },
+        ],
+      },
+      null,
+      2,
+    );
+
+    const result = addPatternToModulesFile(rawContent, ".devcontainer", [".devcontainer/new.sh"]);
+
+    const parsed = JSON.parse(result);
+    expect(parsed.modules[0].patterns).toContain(".devcontainer/devcontainer.json");
+    expect(parsed.modules[0].patterns).toContain(".devcontainer/new.sh");
+  });
+
+  it("重複するパターンは追加しない", () => {
+    const rawContent = JSON.stringify(
+      {
+        modules: [
+          {
+            id: ".devcontainer",
+            name: "DevContainer",
+            description: "Test",
+            patterns: [".devcontainer/devcontainer.json"],
+          },
+        ],
+      },
+      null,
+      2,
+    );
+
+    const result = addPatternToModulesFile(rawContent, ".devcontainer", [
+      ".devcontainer/devcontainer.json",
+    ]);
+
+    // 変更なしの場合は元のコンテンツを返す
+    expect(result).toBe(rawContent);
+  });
+
+  it("存在しないモジュール ID の場合はエラー", () => {
+    const rawContent = JSON.stringify({
+      modules: [
+        {
+          id: ".devcontainer",
+          name: "DevContainer",
+          description: "Test",
+          patterns: [],
+        },
+      ],
+    });
+
+    expect(() => addPatternToModulesFile(rawContent, ".github", ["pattern"])).toThrow(
+      "モジュール .github が見つかりません",
+    );
+  });
+
+  it("複数のパターンを一度に追加できる", () => {
+    const rawContent = JSON.stringify(
+      {
+        modules: [
+          {
+            id: ".github",
+            name: "GitHub",
+            description: "Test",
+            patterns: [".github/workflows/ci.yml"],
+          },
+        ],
+      },
+      null,
+      2,
+    );
+
+    const result = addPatternToModulesFile(rawContent, ".github", [
+      ".github/workflows/test.yml",
+      ".github/labeler.yml",
+    ]);
+
+    const parsed = JSON.parse(result);
+    expect(parsed.modules[0].patterns).toHaveLength(3);
+  });
+});
+
+describe("saveModulesFile", () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it("モジュールファイルを保存できる", async () => {
+    vol.fromJSON({
+      "/project/.devenv": null, // ディレクトリを作成
+    });
+
+    const content = JSON.stringify({ modules: [] });
+    await saveModulesFile("/project", content);
+
+    const saved = vol.readFileSync("/project/.devenv/modules.jsonc", "utf8");
+    expect(saved).toBe(content);
+  });
+
+  it("既存ファイルを上書きできる", async () => {
+    vol.fromJSON({
+      "/project/.devenv/modules.jsonc": "old content",
+    });
+
+    const newContent = JSON.stringify({ modules: [{ id: "new" }] });
+    await saveModulesFile("/project", newContent);
+
+    const saved = vol.readFileSync("/project/.devenv/modules.jsonc", "utf8");
+    expect(saved).toBe(newContent);
+  });
+});
+
+describe("getModulesFilePath", () => {
+  it("正しいパスを返す", () => {
+    expect(getModulesFilePath("/project")).toBe("/project/.devenv/modules.jsonc");
+  });
+
+  it("末尾スラッシュなしでも正しく動作する", () => {
+    expect(getModulesFilePath("/path/to/project")).toBe("/path/to/project/.devenv/modules.jsonc");
+  });
+});
+
+describe("modulesFileExists", () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it("ファイルが存在する場合は true を返す", () => {
+    vol.fromJSON({
+      "/project/.devenv/modules.jsonc": "{}",
+    });
+
+    expect(modulesFileExists("/project")).toBe(true);
+  });
+
+  it("ファイルが存在しない場合は false を返す", () => {
+    vol.fromJSON({});
+
+    expect(modulesFileExists("/project")).toBe(false);
+  });
+
+  it("ディレクトリのみ存在してファイルがない場合は false を返す", () => {
+    vol.fromJSON({
+      "/project/.devenv": null,
+    });
+
+    expect(modulesFileExists("/project")).toBe(false);
+  });
+});

--- a/packages/create-devenv/src/modules/__tests__/schemas.test.ts
+++ b/packages/create-devenv/src/modules/__tests__/schemas.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from "vitest";
+import {
+  answersSchema,
+  configSchema,
+  diffResultSchema,
+  diffTypeSchema,
+  fileActionSchema,
+  fileDiffSchema,
+  fileOperationResultSchema,
+  filePathSchema,
+  moduleSchema,
+  nonNegativeIntSchema,
+  overwriteStrategySchema,
+  prResultSchema,
+} from "../schemas";
+
+describe("nonNegativeIntSchema", () => {
+  it("0 を受け入れる", () => {
+    expect(nonNegativeIntSchema.parse(0)).toBe(0);
+  });
+
+  it("正の整数を受け入れる", () => {
+    expect(nonNegativeIntSchema.parse(42)).toBe(42);
+  });
+
+  it("負の数を拒否する", () => {
+    expect(() => nonNegativeIntSchema.parse(-1)).toThrow();
+  });
+
+  it("小数を拒否する", () => {
+    expect(() => nonNegativeIntSchema.parse(1.5)).toThrow();
+  });
+});
+
+describe("filePathSchema", () => {
+  it("有効なファイルパスを受け入れる", () => {
+    expect(filePathSchema.parse("file.txt")).toBe("file.txt");
+    expect(filePathSchema.parse("/path/to/file.txt")).toBe("/path/to/file.txt");
+  });
+
+  it("空文字列を拒否する", () => {
+    expect(() => filePathSchema.parse("")).toThrow();
+  });
+});
+
+describe("overwriteStrategySchema", () => {
+  it("overwrite を受け入れる", () => {
+    expect(overwriteStrategySchema.parse("overwrite")).toBe("overwrite");
+  });
+
+  it("skip を受け入れる", () => {
+    expect(overwriteStrategySchema.parse("skip")).toBe("skip");
+  });
+
+  it("prompt を受け入れる", () => {
+    expect(overwriteStrategySchema.parse("prompt")).toBe("prompt");
+  });
+
+  it("無効な値を拒否する", () => {
+    expect(() => overwriteStrategySchema.parse("invalid")).toThrow();
+  });
+});
+
+describe("fileActionSchema", () => {
+  it("全てのアクションタイプを受け入れる", () => {
+    expect(fileActionSchema.parse("copied")).toBe("copied");
+    expect(fileActionSchema.parse("created")).toBe("created");
+    expect(fileActionSchema.parse("overwritten")).toBe("overwritten");
+    expect(fileActionSchema.parse("skipped")).toBe("skipped");
+  });
+
+  it("無効な値を拒否する", () => {
+    expect(() => fileActionSchema.parse("deleted")).toThrow();
+  });
+});
+
+describe("fileOperationResultSchema", () => {
+  it("有効な操作結果を受け入れる", () => {
+    const result = { action: "copied", path: "file.txt" };
+    expect(fileOperationResultSchema.parse(result)).toEqual(result);
+  });
+
+  it("action が欠けている場合は拒否する", () => {
+    expect(() => fileOperationResultSchema.parse({ path: "file.txt" })).toThrow();
+  });
+
+  it("path が欠けている場合は拒否する", () => {
+    expect(() => fileOperationResultSchema.parse({ action: "copied" })).toThrow();
+  });
+});
+
+describe("moduleSchema", () => {
+  it("有効なモジュールを受け入れる", () => {
+    const module = {
+      id: ".devcontainer",
+      name: "DevContainer",
+      description: "VS Code DevContainer 設定",
+      patterns: [".devcontainer/**"],
+    };
+    expect(moduleSchema.parse(module)).toEqual(module);
+  });
+
+  it("setupDescription を含むモジュールを受け入れる", () => {
+    const module = {
+      id: ".devcontainer",
+      name: "DevContainer",
+      description: "VS Code DevContainer 設定",
+      setupDescription: "VS Code で開くとセットアップされます",
+      patterns: [".devcontainer/**"],
+    };
+    expect(moduleSchema.parse(module)).toEqual(module);
+  });
+
+  it("必須フィールドが欠けている場合は拒否する", () => {
+    expect(() =>
+      moduleSchema.parse({
+        id: ".devcontainer",
+        name: "DevContainer",
+        // description が欠けている
+        patterns: [],
+      }),
+    ).toThrow();
+  });
+
+  it("空のパターン配列を受け入れる", () => {
+    const module = {
+      id: "test",
+      name: "Test",
+      description: "Test module",
+      patterns: [],
+    };
+    expect(moduleSchema.parse(module)).toEqual(module);
+  });
+});
+
+describe("configSchema", () => {
+  it("有効な設定を受け入れる", () => {
+    const config = {
+      version: "1.0.0",
+      installedAt: "2024-01-01T00:00:00+09:00",
+      modules: [".devcontainer", ".github"],
+      source: {
+        owner: "tktcorporation",
+        repo: ".github",
+      },
+    };
+    expect(configSchema.parse(config)).toEqual(config);
+  });
+
+  it("ref を含む source を受け入れる", () => {
+    const config = {
+      version: "1.0.0",
+      installedAt: "2024-01-01T00:00:00+09:00",
+      modules: [],
+      source: {
+        owner: "tktcorporation",
+        repo: ".github",
+        ref: "main",
+      },
+    };
+    expect(configSchema.parse(config)).toEqual(config);
+  });
+
+  it("excludePatterns を受け入れる", () => {
+    const config = {
+      version: "1.0.0",
+      installedAt: "2024-01-01T00:00:00+09:00",
+      modules: [],
+      source: {
+        owner: "tktcorporation",
+        repo: ".github",
+      },
+      excludePatterns: ["*.local", ".env"],
+    };
+    expect(configSchema.parse(config)).toEqual(config);
+  });
+
+  it("不正な datetime 形式を拒否する", () => {
+    expect(() =>
+      configSchema.parse({
+        version: "1.0.0",
+        installedAt: "invalid-date",
+        modules: [],
+        source: { owner: "test", repo: "test" },
+      }),
+    ).toThrow();
+  });
+
+  it("ISO 8601 形式の datetime を受け入れる", () => {
+    const config = {
+      version: "1.0.0",
+      installedAt: "2024-06-15T10:30:00Z",
+      modules: [],
+      source: { owner: "test", repo: "test" },
+    };
+    expect(configSchema.parse(config)).toEqual(config);
+  });
+});
+
+describe("answersSchema", () => {
+  it("有効な回答を受け入れる", () => {
+    const answers = {
+      modules: [".devcontainer"],
+      overwriteStrategy: "overwrite",
+    };
+    expect(answersSchema.parse(answers)).toEqual(answers);
+  });
+
+  it("空のモジュール配列を拒否する", () => {
+    expect(() =>
+      answersSchema.parse({
+        modules: [],
+        overwriteStrategy: "skip",
+      }),
+    ).toThrow();
+  });
+
+  it("複数のモジュールを受け入れる", () => {
+    const answers = {
+      modules: [".devcontainer", ".github", ".claude"],
+      overwriteStrategy: "prompt",
+    };
+    expect(answersSchema.parse(answers)).toEqual(answers);
+  });
+});
+
+describe("diffTypeSchema", () => {
+  it("全ての差分タイプを受け入れる", () => {
+    expect(diffTypeSchema.parse("added")).toBe("added");
+    expect(diffTypeSchema.parse("modified")).toBe("modified");
+    expect(diffTypeSchema.parse("deleted")).toBe("deleted");
+    expect(diffTypeSchema.parse("unchanged")).toBe("unchanged");
+  });
+
+  it("無効な値を拒否する", () => {
+    expect(() => diffTypeSchema.parse("changed")).toThrow();
+  });
+});
+
+describe("fileDiffSchema", () => {
+  it("有効なファイル差分を受け入れる", () => {
+    const diff = {
+      path: "file.txt",
+      type: "modified",
+      localContent: "local",
+      templateContent: "template",
+    };
+    expect(fileDiffSchema.parse(diff)).toEqual(diff);
+  });
+
+  it("コンテンツなしの差分を受け入れる（deleted の場合）", () => {
+    const diff = {
+      path: "file.txt",
+      type: "deleted",
+      templateContent: "template",
+    };
+    expect(fileDiffSchema.parse(diff)).toEqual(diff);
+  });
+
+  it("コンテンツなしの差分を受け入れる（added の場合）", () => {
+    const diff = {
+      path: "file.txt",
+      type: "added",
+      localContent: "local",
+    };
+    expect(fileDiffSchema.parse(diff)).toEqual(diff);
+  });
+});
+
+describe("diffResultSchema", () => {
+  it("有効な差分結果を受け入れる", () => {
+    const result = {
+      files: [
+        { path: "file.txt", type: "modified" },
+      ],
+      summary: {
+        added: 1,
+        modified: 2,
+        deleted: 0,
+        unchanged: 5,
+      },
+    };
+    expect(diffResultSchema.parse(result)).toEqual(result);
+  });
+
+  it("空のファイル配列を受け入れる", () => {
+    const result = {
+      files: [],
+      summary: {
+        added: 0,
+        modified: 0,
+        deleted: 0,
+        unchanged: 0,
+      },
+    };
+    expect(diffResultSchema.parse(result)).toEqual(result);
+  });
+});
+
+describe("prResultSchema", () => {
+  it("有効な PR 結果を受け入れる", () => {
+    const result = {
+      url: "https://github.com/owner/repo/pull/123",
+      number: 123,
+      branch: "devenv-sync-1234567890",
+    };
+    expect(prResultSchema.parse(result)).toEqual(result);
+  });
+
+  it("必須フィールドが欠けている場合は拒否する", () => {
+    expect(() =>
+      prResultSchema.parse({
+        url: "https://github.com/owner/repo/pull/123",
+        // number が欠けている
+        branch: "main",
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/create-devenv/src/utils/__tests__/config.test.ts
+++ b/packages/create-devenv/src/utils/__tests__/config.test.ts
@@ -1,0 +1,179 @@
+import { vol } from "memfs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// fs モジュールをモック
+vi.mock("node:fs/promises", async () => {
+  const memfs = await import("memfs");
+  return memfs.fs.promises;
+});
+
+vi.mock("node:fs", async () => {
+  const memfs = await import("memfs");
+  return memfs.fs;
+});
+
+// モック後にインポート
+const { loadConfig, saveConfig } = await import("../config");
+
+describe("loadConfig", () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it("正常な .devenv.json を読み込める", async () => {
+    const config = {
+      version: "1.0.0",
+      installedAt: "2024-01-01T00:00:00+09:00",
+      modules: [".devcontainer", ".github"],
+      source: {
+        owner: "tktcorporation",
+        repo: ".github",
+        ref: "main",
+      },
+    };
+
+    vol.fromJSON({
+      "/project/.devenv.json": JSON.stringify(config),
+    });
+
+    const result = await loadConfig("/project");
+
+    expect(result).toEqual(config);
+  });
+
+  it("excludePatterns を含む設定を読み込める", async () => {
+    const config = {
+      version: "1.0.0",
+      installedAt: "2024-01-01T00:00:00+09:00",
+      modules: [".devcontainer"],
+      source: {
+        owner: "tktcorporation",
+        repo: ".github",
+      },
+      excludePatterns: ["*.local", ".env"],
+    };
+
+    vol.fromJSON({
+      "/project/.devenv.json": JSON.stringify(config),
+    });
+
+    const result = await loadConfig("/project");
+
+    expect(result.excludePatterns).toEqual(["*.local", ".env"]);
+  });
+
+  it("ファイルが存在しない場合はエラー", async () => {
+    vol.fromJSON({});
+
+    await expect(loadConfig("/project")).rejects.toThrow();
+  });
+
+  it("不正な JSON の場合はエラー", async () => {
+    vol.fromJSON({
+      "/project/.devenv.json": "{ invalid json }",
+    });
+
+    await expect(loadConfig("/project")).rejects.toThrow();
+  });
+
+  it("スキーマに合わない場合はエラー", async () => {
+    vol.fromJSON({
+      "/project/.devenv.json": JSON.stringify({
+        version: "1.0.0",
+        // installedAt が欠けている
+        modules: [],
+        source: { owner: "test", repo: "test" },
+      }),
+    });
+
+    await expect(loadConfig("/project")).rejects.toThrow();
+  });
+
+  it("installedAt が不正な datetime 形式の場合はエラー", async () => {
+    vol.fromJSON({
+      "/project/.devenv.json": JSON.stringify({
+        version: "1.0.0",
+        installedAt: "invalid-date",
+        modules: [],
+        source: { owner: "test", repo: "test" },
+      }),
+    });
+
+    await expect(loadConfig("/project")).rejects.toThrow();
+  });
+});
+
+describe("saveConfig", () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it("設定を JSON ファイルとして保存できる", async () => {
+    vol.fromJSON({
+      "/project": null, // ディレクトリを作成
+    });
+
+    const config = {
+      version: "1.0.0",
+      installedAt: "2024-01-01T00:00:00+09:00",
+      modules: [".devcontainer", ".github"],
+      source: {
+        owner: "tktcorporation",
+        repo: ".github",
+        ref: "main",
+      },
+    };
+
+    await saveConfig("/project", config);
+
+    const saved = vol.readFileSync("/project/.devenv.json", "utf8");
+    expect(JSON.parse(saved as string)).toEqual(config);
+  });
+
+  it("保存される JSON は整形されている（2スペースインデント）", async () => {
+    vol.fromJSON({
+      "/project": null,
+    });
+
+    const config = {
+      version: "1.0.0",
+      installedAt: "2024-01-01T00:00:00+09:00",
+      modules: [".devcontainer"],
+      source: {
+        owner: "tktcorporation",
+        repo: ".github",
+      },
+    };
+
+    await saveConfig("/project", config);
+
+    const saved = vol.readFileSync("/project/.devenv.json", "utf8") as string;
+
+    // 整形されていることを確認
+    expect(saved).toContain("\n");
+    expect(saved).toContain("  "); // 2スペースインデント
+    // 末尾に改行があることを確認
+    expect(saved.endsWith("\n")).toBe(true);
+  });
+
+  it("既存ファイルを上書きできる", async () => {
+    vol.fromJSON({
+      "/project/.devenv.json": JSON.stringify({ old: "data" }),
+    });
+
+    const newConfig = {
+      version: "2.0.0",
+      installedAt: "2024-06-01T00:00:00+09:00",
+      modules: [".claude"],
+      source: {
+        owner: "tktcorporation",
+        repo: ".github",
+      },
+    };
+
+    await saveConfig("/project", newConfig);
+
+    const saved = vol.readFileSync("/project/.devenv.json", "utf8");
+    expect(JSON.parse(saved as string)).toEqual(newConfig);
+  });
+});

--- a/packages/create-devenv/src/utils/__tests__/diff-viewer.test.ts
+++ b/packages/create-devenv/src/utils/__tests__/diff-viewer.test.ts
@@ -1,0 +1,374 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FileDiff } from "../../modules/schemas";
+import {
+  addStatsToFiles,
+  calculateDiffStats,
+  calculateTotalStats,
+  formatStats,
+  formatStatsWithLabel,
+  getFileLabel,
+  groupFilesByType,
+  showDiffSummaryBox,
+  showFileDiffBox,
+} from "../diff-viewer";
+
+// console.log をモック
+const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+describe("calculateDiffStats", () => {
+  it("unchanged ファイルは追加・削除 0", () => {
+    const file: FileDiff = {
+      path: "file.txt",
+      type: "unchanged",
+      localContent: "content",
+      templateContent: "content",
+    };
+
+    const stats = calculateDiffStats(file);
+
+    expect(stats.additions).toBe(0);
+    expect(stats.deletions).toBe(0);
+  });
+
+  it("deleted ファイルは削除行数をカウント", () => {
+    const file: FileDiff = {
+      path: "file.txt",
+      type: "deleted",
+      templateContent: "line1\nline2\nline3",
+    };
+
+    const stats = calculateDiffStats(file);
+
+    expect(stats.additions).toBe(0);
+    expect(stats.deletions).toBe(3);
+  });
+
+  it("added ファイルは追加行数をカウント", () => {
+    const file: FileDiff = {
+      path: "file.txt",
+      type: "added",
+      localContent: "line1\nline2",
+    };
+
+    const stats = calculateDiffStats(file);
+
+    expect(stats.additions).toBe(2);
+    expect(stats.deletions).toBe(0);
+  });
+
+  it("modified ファイルは追加・削除行数をカウント", () => {
+    const file: FileDiff = {
+      path: "file.txt",
+      type: "modified",
+      localContent: "new line 1\nline 2",
+      templateContent: "old line 1\nline 2",
+    };
+
+    const stats = calculateDiffStats(file);
+
+    // 1行が変更された = 1追加 + 1削除
+    expect(stats.additions).toBe(1);
+    expect(stats.deletions).toBe(1);
+  });
+
+  it("空の localContent の added ファイル", () => {
+    const file: FileDiff = {
+      path: "file.txt",
+      type: "added",
+      localContent: "",
+    };
+
+    const stats = calculateDiffStats(file);
+
+    expect(stats.additions).toBe(0);
+    expect(stats.deletions).toBe(0);
+  });
+
+  it("undefined の templateContent の deleted ファイル", () => {
+    const file: FileDiff = {
+      path: "file.txt",
+      type: "deleted",
+      templateContent: undefined,
+    };
+
+    const stats = calculateDiffStats(file);
+
+    expect(stats.deletions).toBe(0);
+  });
+});
+
+describe("addStatsToFiles", () => {
+  it("各ファイルに統計情報を追加する", () => {
+    const files: FileDiff[] = [
+      { path: "a.txt", type: "added", localContent: "line1\nline2" },
+      { path: "b.txt", type: "deleted", templateContent: "line1" },
+    ];
+
+    const result = addStatsToFiles(files);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].stats.additions).toBe(2);
+    expect(result[1].stats.deletions).toBe(1);
+  });
+
+  it("空の配列を処理できる", () => {
+    const result = addStatsToFiles([]);
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("groupFilesByType", () => {
+  it("ファイルをタイプ別にグループ化する", () => {
+    const files = addStatsToFiles([
+      { path: "a.txt", type: "added", localContent: "content" },
+      { path: "b.txt", type: "modified", localContent: "new", templateContent: "old" },
+      { path: "c.txt", type: "deleted", templateContent: "content" },
+      { path: "d.txt", type: "added", localContent: "content" },
+    ]);
+
+    const result = groupFilesByType(files);
+
+    expect(result.added).toHaveLength(2);
+    expect(result.modified).toHaveLength(1);
+    expect(result.deleted).toHaveLength(1);
+  });
+
+  it("unchanged はグループ化されない", () => {
+    const files = addStatsToFiles([
+      { path: "a.txt", type: "unchanged", localContent: "content", templateContent: "content" },
+    ]);
+
+    const result = groupFilesByType(files);
+
+    expect(result.added).toHaveLength(0);
+    expect(result.modified).toHaveLength(0);
+    expect(result.deleted).toHaveLength(0);
+  });
+});
+
+describe("calculateTotalStats", () => {
+  it("全ファイルの統計を合計する", () => {
+    const files = addStatsToFiles([
+      { path: "a.txt", type: "added", localContent: "line1\nline2" },
+      { path: "b.txt", type: "deleted", templateContent: "line1\nline2\nline3" },
+    ]);
+
+    const result = calculateTotalStats(files);
+
+    expect(result.additions).toBe(2);
+    expect(result.deletions).toBe(3);
+  });
+
+  it("空の配列は 0 を返す", () => {
+    const result = calculateTotalStats([]);
+
+    expect(result.additions).toBe(0);
+    expect(result.deletions).toBe(0);
+  });
+});
+
+describe("formatStats", () => {
+  beforeEach(() => {
+    consoleSpy.mockClear();
+  });
+
+  it("追加のみの場合は +N 形式", () => {
+    const result = formatStats({ additions: 10, deletions: 0 });
+
+    // ANSI カラーコードを含むため、数値のみチェック
+    expect(result).toContain("+10");
+  });
+
+  it("削除のみの場合は -N 形式", () => {
+    const result = formatStats({ additions: 0, deletions: 5 });
+
+    expect(result).toContain("-5");
+  });
+
+  it("追加と削除がある場合は +N -M 形式", () => {
+    const result = formatStats({ additions: 10, deletions: 5 });
+
+    expect(result).toContain("+10");
+    expect(result).toContain("-5");
+  });
+
+  it("変更なしの場合は (no changes) を返す", () => {
+    const result = formatStats({ additions: 0, deletions: 0 });
+
+    expect(result).toContain("no changes");
+  });
+});
+
+describe("formatStatsWithLabel", () => {
+  it("追加と削除がある場合は +N -M lines 形式", () => {
+    const result = formatStatsWithLabel({ additions: 10, deletions: 5 });
+
+    expect(result).toContain("+10");
+    expect(result).toContain("-5");
+    expect(result).toContain("lines");
+  });
+
+  it("変更なしの場合は空文字列を返す", () => {
+    const result = formatStatsWithLabel({ additions: 0, deletions: 0 });
+
+    expect(result).toBe("");
+  });
+});
+
+describe("getFileLabel", () => {
+  it("ファイルのラベルを生成する", () => {
+    const file: FileDiff = {
+      path: "file.txt",
+      type: "added",
+      localContent: "line1\nline2",
+    };
+
+    const label = getFileLabel(file);
+
+    expect(label).toContain("file.txt");
+    expect(label).toContain("+2");
+  });
+
+  it("modified ファイルのラベル", () => {
+    const file: FileDiff = {
+      path: "file.txt",
+      type: "modified",
+      localContent: "new line",
+      templateContent: "old line",
+    };
+
+    const label = getFileLabel(file);
+
+    expect(label).toContain("file.txt");
+  });
+});
+
+describe("showDiffSummaryBox", () => {
+  beforeEach(() => {
+    consoleSpy.mockClear();
+  });
+
+  it("コンソールに出力する", () => {
+    const files: FileDiff[] = [
+      { path: "a.txt", type: "added", localContent: "content" },
+    ];
+
+    showDiffSummaryBox(files);
+
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it("空のファイルリストでも動作する", () => {
+    showDiffSummaryBox([]);
+
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it("複数タイプのファイルを表示する", () => {
+    const files: FileDiff[] = [
+      { path: "a.txt", type: "added", localContent: "content" },
+      { path: "b.txt", type: "modified", localContent: "new", templateContent: "old" },
+      { path: "c.txt", type: "deleted", templateContent: "content" },
+    ];
+
+    showDiffSummaryBox(files);
+
+    const output = consoleSpy.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain("a.txt");
+    expect(output).toContain("b.txt");
+    expect(output).toContain("c.txt");
+  });
+});
+
+describe("showFileDiffBox", () => {
+  beforeEach(() => {
+    consoleSpy.mockClear();
+  });
+
+  it("ファイルの diff ボックスを表示する", () => {
+    const file: FileDiff = {
+      path: "file.txt",
+      type: "modified",
+      localContent: "new line",
+      templateContent: "old line",
+    };
+
+    showFileDiffBox(file, 0, 1);
+
+    expect(consoleSpy).toHaveBeenCalled();
+    const output = consoleSpy.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain("file.txt");
+    expect(output).toContain("[1/1]");
+  });
+
+  it("added ファイルの diff を表示する", () => {
+    const file: FileDiff = {
+      path: "new-file.txt",
+      type: "added",
+      localContent: "new content",
+    };
+
+    showFileDiffBox(file, 0, 1);
+
+    const output = consoleSpy.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain("new-file.txt");
+    expect(output).toContain("added");
+  });
+
+  it("deleted ファイルの diff を表示する", () => {
+    const file: FileDiff = {
+      path: "deleted-file.txt",
+      type: "deleted",
+      templateContent: "old content",
+    };
+
+    showFileDiffBox(file, 0, 1);
+
+    const output = consoleSpy.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain("deleted-file.txt");
+    expect(output).toContain("deleted");
+  });
+
+  it("maxLines オプションで行数を制限する", () => {
+    const file: FileDiff = {
+      path: "large-file.txt",
+      type: "modified",
+      localContent: "line1\nline2\nline3\nline4\nline5",
+      templateContent: "old1\nold2\nold3\nold4\nold5",
+    };
+
+    showFileDiffBox(file, 0, 1, { maxLines: 3 });
+
+    const output = consoleSpy.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain("more lines");
+  });
+
+  it("syntaxHighlight オプションが動作する", () => {
+    const file: FileDiff = {
+      path: "file.ts",
+      type: "modified",
+      localContent: "const x = 1;",
+      templateContent: "const x = 2;",
+    };
+
+    // エラーなく実行される
+    showFileDiffBox(file, 0, 1, { syntaxHighlight: true });
+
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it("wordDiff オプションが動作する", () => {
+    const file: FileDiff = {
+      path: "file.txt",
+      type: "modified",
+      localContent: "hello world",
+      templateContent: "hello there",
+    };
+
+    // エラーなく実行される
+    showFileDiffBox(file, 0, 1, { wordDiff: true });
+
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/create-devenv/src/utils/__tests__/github.test.ts
+++ b/packages/create-devenv/src/utils/__tests__/github.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getGitHubToken } from "../github";
+
+// Octokit をモック
+const mockGetAuthenticated = vi.fn();
+const mockReposGet = vi.fn();
+const mockReposCreateFork = vi.fn();
+const mockReposGetBranch = vi.fn();
+const mockGitCreateRef = vi.fn();
+const mockReposGetContent = vi.fn();
+const mockReposCreateOrUpdateFileContents = vi.fn();
+const mockPullsCreate = vi.fn();
+
+vi.mock("@octokit/rest", () => ({
+  Octokit: class MockOctokit {
+    users = {
+      getAuthenticated: mockGetAuthenticated,
+    };
+    repos = {
+      get: mockReposGet,
+      createFork: mockReposCreateFork,
+      getBranch: mockReposGetBranch,
+      getContent: mockReposGetContent,
+      createOrUpdateFileContents: mockReposCreateOrUpdateFileContents,
+    };
+    git = {
+      createRef: mockGitCreateRef,
+    };
+    pulls = {
+      create: mockPullsCreate,
+    };
+  },
+}));
+
+// モック後にインポート
+const { createPullRequest } = await import("../github");
+
+describe("getGitHubToken", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("GITHUB_TOKEN を返す", () => {
+    process.env.GITHUB_TOKEN = "ghp_test123";
+    delete process.env.GH_TOKEN;
+
+    expect(getGitHubToken()).toBe("ghp_test123");
+  });
+
+  it("GITHUB_TOKEN がない場合は GH_TOKEN を返す", () => {
+    delete process.env.GITHUB_TOKEN;
+    process.env.GH_TOKEN = "ghp_gh_token";
+
+    expect(getGitHubToken()).toBe("ghp_gh_token");
+  });
+
+  it("どちらもない場合は undefined を返す", () => {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+
+    expect(getGitHubToken()).toBeUndefined();
+  });
+
+  it("両方ある場合は GITHUB_TOKEN を優先する", () => {
+    process.env.GITHUB_TOKEN = "ghp_github";
+    process.env.GH_TOKEN = "ghp_gh";
+
+    expect(getGitHubToken()).toBe("ghp_github");
+  });
+});
+
+describe("createPullRequest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // デフォルトのモック設定
+    mockGetAuthenticated.mockResolvedValue({
+      data: { login: "testuser" },
+    });
+
+    mockReposGet.mockResolvedValue({
+      data: { name: "test-repo" },
+    });
+
+    mockReposGetBranch.mockResolvedValue({
+      data: { commit: { sha: "abc123" } },
+    });
+
+    mockGitCreateRef.mockResolvedValue({});
+
+    mockReposGetContent.mockRejectedValue(new Error("Not found"));
+
+    mockReposCreateOrUpdateFileContents.mockResolvedValue({});
+
+    mockPullsCreate.mockResolvedValue({
+      data: {
+        html_url: "https://github.com/owner/repo/pull/123",
+        number: 123,
+      },
+    });
+  });
+
+  it("PR を作成できる", async () => {
+    const result = await createPullRequest("token", {
+      owner: "owner",
+      repo: "repo",
+      files: [{ path: "file.txt", content: "content" }],
+      title: "Test PR",
+    });
+
+    expect(result.url).toBe("https://github.com/owner/repo/pull/123");
+    expect(result.number).toBe(123);
+    expect(result.branch).toMatch(/^devenv-sync-\d+$/);
+  });
+
+  it("既存の fork を使用する", async () => {
+    mockReposGet.mockResolvedValue({
+      data: { name: "repo" },
+    });
+
+    await createPullRequest("token", {
+      owner: "owner",
+      repo: "repo",
+      files: [{ path: "file.txt", content: "content" }],
+      title: "Test PR",
+    });
+
+    expect(mockReposGet).toHaveBeenCalledWith({
+      owner: "testuser",
+      repo: "repo",
+    });
+    expect(mockReposCreateFork).not.toHaveBeenCalled();
+  });
+
+  it("fork が存在しない場合は作成する", async () => {
+    mockReposGet.mockRejectedValue(new Error("Not found"));
+    mockReposCreateFork.mockResolvedValue({
+      data: { name: "repo" },
+    });
+
+    await createPullRequest("token", {
+      owner: "owner",
+      repo: "repo",
+      files: [{ path: "file.txt", content: "content" }],
+      title: "Test PR",
+    });
+
+    expect(mockReposCreateFork).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+    });
+  });
+
+  it("複数のファイルをコミットする", async () => {
+    await createPullRequest("token", {
+      owner: "owner",
+      repo: "repo",
+      files: [
+        { path: "file1.txt", content: "content1" },
+        { path: "file2.txt", content: "content2" },
+      ],
+      title: "Test PR",
+    });
+
+    expect(mockReposCreateOrUpdateFileContents).toHaveBeenCalledTimes(2);
+  });
+
+  it("既存ファイルを更新する", async () => {
+    mockReposGetContent.mockResolvedValue({
+      data: { type: "file", sha: "existing-sha" },
+    });
+
+    await createPullRequest("token", {
+      owner: "owner",
+      repo: "repo",
+      files: [{ path: "existing.txt", content: "new content" }],
+      title: "Test PR",
+    });
+
+    expect(mockReposCreateOrUpdateFileContents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sha: "existing-sha",
+      }),
+    );
+  });
+
+  it("カスタム baseBranch を使用する", async () => {
+    await createPullRequest("token", {
+      owner: "owner",
+      repo: "repo",
+      files: [{ path: "file.txt", content: "content" }],
+      title: "Test PR",
+      baseBranch: "develop",
+    });
+
+    expect(mockReposGetBranch).toHaveBeenCalledWith({
+      owner: "owner",
+      repo: "repo",
+      branch: "develop",
+    });
+
+    expect(mockPullsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        base: "develop",
+      }),
+    );
+  });
+
+  it("カスタム body を使用する", async () => {
+    await createPullRequest("token", {
+      owner: "owner",
+      repo: "repo",
+      files: [{ path: "file.txt", content: "content" }],
+      title: "Test PR",
+      body: "Custom body content",
+    });
+
+    expect(mockPullsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: "Custom body content",
+      }),
+    );
+  });
+
+  it("body がない場合は自動生成する", async () => {
+    await createPullRequest("token", {
+      owner: "owner",
+      repo: "repo",
+      files: [{ path: "file.txt", content: "content" }],
+      title: "Test PR",
+    });
+
+    expect(mockPullsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining("file.txt"),
+      }),
+    );
+  });
+
+  it("正しいヘッドブランチ形式で PR を作成する", async () => {
+    await createPullRequest("token", {
+      owner: "owner",
+      repo: "repo",
+      files: [{ path: "file.txt", content: "content" }],
+      title: "Test PR",
+    });
+
+    expect(mockPullsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        head: expect.stringMatching(/^testuser:devenv-sync-\d+$/),
+      }),
+    );
+  });
+
+  it("ファイル内容を Base64 エンコードする", async () => {
+    await createPullRequest("token", {
+      owner: "owner",
+      repo: "repo",
+      files: [{ path: "file.txt", content: "Hello, World!" }],
+      title: "Test PR",
+    });
+
+    const expectedBase64 = Buffer.from("Hello, World!").toString("base64");
+    expect(mockReposCreateOrUpdateFileContents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expectedBase64,
+      }),
+    );
+  });
+});

--- a/packages/create-devenv/src/utils/__tests__/patterns.test.ts
+++ b/packages/create-devenv/src/utils/__tests__/patterns.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  mergePatterns,
+  filterByExcludePatterns,
+  getEffectivePatterns,
+  matchesPatterns,
+} from "../patterns";
+
+describe("mergePatterns", () => {
+  it("複数の配列をマージする", () => {
+    const result = mergePatterns(["a", "b"], ["c", "d"]);
+
+    expect(result).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("重複を排除する", () => {
+    const result = mergePatterns(["a", "b"], ["b", "c"]);
+
+    expect(result).toEqual(["a", "b", "c"]);
+  });
+
+  it("空配列を処理できる", () => {
+    const result = mergePatterns([], ["a", "b"], []);
+
+    expect(result).toEqual(["a", "b"]);
+  });
+
+  it("3つ以上の配列をマージできる", () => {
+    const result = mergePatterns(["a"], ["b"], ["c"], ["d"]);
+
+    expect(result).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("引数なしの場合は空配列を返す", () => {
+    const result = mergePatterns();
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("filterByExcludePatterns", () => {
+  it("除外パターンにマッチするファイルを除外する", () => {
+    const files = ["file.txt", "file.local", "config.json"];
+
+    const result = filterByExcludePatterns(files, ["file.local"]);
+
+    expect(result).toEqual(["file.txt", "config.json"]);
+  });
+
+  it("除外パターンが空の場合は全ファイルを返す", () => {
+    const files = ["file.txt", "config.json"];
+
+    const result = filterByExcludePatterns(files, []);
+
+    expect(result).toEqual(files);
+  });
+
+  it("除外パターンが undefined の場合は全ファイルを返す", () => {
+    const files = ["file.txt", "config.json"];
+
+    const result = filterByExcludePatterns(files, undefined);
+
+    expect(result).toEqual(files);
+  });
+});
+
+describe("getEffectivePatterns", () => {
+  it("設定がない場合はモジュールパターンをそのまま返す", () => {
+    const patterns = ["*.json", "*.ts"];
+
+    const result = getEffectivePatterns("test", patterns, undefined);
+
+    expect(result).toEqual(["*.json", "*.ts"]);
+  });
+
+  it("excludePatterns がない設定の場合はそのまま返す", () => {
+    const patterns = ["*.json", "*.ts"];
+    const config = {
+      version: "1.0.0",
+      installedAt: "2024-01-01T00:00:00+09:00",
+      modules: [],
+      source: { owner: "test", repo: "test" },
+    };
+
+    const result = getEffectivePatterns("test", patterns, config);
+
+    expect(result).toEqual(["*.json", "*.ts"]);
+  });
+
+  it("excludePatterns にマッチするパターンを除外する", () => {
+    const patterns = ["config.json", "settings.local.json", "data.json"];
+    const config = {
+      version: "1.0.0",
+      installedAt: "2024-01-01T00:00:00+09:00",
+      modules: [],
+      source: { owner: "test", repo: "test" },
+      excludePatterns: ["settings.local.json"],
+    };
+
+    const result = getEffectivePatterns("test", patterns, config);
+
+    expect(result).toEqual(["config.json", "data.json"]);
+  });
+});
+
+describe("matchesPatterns", () => {
+  it("完全一致するファイルを検出する", () => {
+    expect(matchesPatterns("file.txt", ["file.txt"])).toBe(true);
+  });
+
+  it("マッチしない場合は false を返す", () => {
+    expect(matchesPatterns("file.txt", ["other.txt"])).toBe(false);
+  });
+
+  it("複数パターンのいずれかにマッチする場合は true", () => {
+    expect(matchesPatterns("file.txt", ["other.txt", "file.txt"])).toBe(true);
+  });
+
+  it("空のパターン配列の場合は false", () => {
+    expect(matchesPatterns("file.txt", [])).toBe(false);
+  });
+});
+
+// resolvePatterns と compareDirectories は実際のファイルシステムに依存するため、
+// 統合テストとしてテストするか、別途モックを用意する必要があります。
+// ここでは純粋関数のみをテストしています。

--- a/packages/create-devenv/src/utils/__tests__/readme.test.ts
+++ b/packages/create-devenv/src/utils/__tests__/readme.test.ts
@@ -1,0 +1,329 @@
+import { vol } from "memfs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// fs モジュールをモック
+vi.mock("node:fs", async () => {
+  const memfs = await import("memfs");
+  return memfs.fs;
+});
+
+vi.mock("node:fs/promises", async () => {
+  const memfs = await import("memfs");
+  return memfs.fs.promises;
+});
+
+// モック後にインポート
+const { generateReadme, updateReadmeFile, detectAndUpdateReadme } = await import("../readme");
+
+describe("generateReadme", () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it("README が存在しない場合は updated: false を返す", async () => {
+    vol.fromJSON({});
+
+    const result = await generateReadme({
+      readmePath: "/project/README.md",
+      modulesPath: "/project/.devenv/modules.jsonc",
+    });
+
+    expect(result.updated).toBe(false);
+    expect(result.content).toBe("");
+  });
+
+  it("マーカーがない README は更新しない", async () => {
+    const originalReadme = "# My Project\n\nSome content";
+    vol.fromJSON({
+      "/project/README.md": originalReadme,
+      "/project/.devenv/modules.jsonc": JSON.stringify({ modules: [] }),
+    });
+
+    const result = await generateReadme({
+      readmePath: "/project/README.md",
+      modulesPath: "/project/.devenv/modules.jsonc",
+    });
+
+    expect(result.updated).toBe(false);
+    expect(result.content).toBe(originalReadme);
+  });
+
+  it("FEATURES マーカー間のコンテンツを更新する", async () => {
+    const readme = `# My Project
+
+<!-- FEATURES:START -->
+Old content
+<!-- FEATURES:END -->
+
+Other content`;
+
+    const modulesJson = JSON.stringify({
+      modules: [
+        { id: ".devcontainer", name: "DevContainer", description: "Docker 開発環境", patterns: [] },
+      ],
+    });
+
+    vol.fromJSON({
+      "/project/README.md": readme,
+      "/project/.devenv/modules.jsonc": modulesJson,
+    });
+
+    const result = await generateReadme({
+      readmePath: "/project/README.md",
+      modulesPath: "/project/.devenv/modules.jsonc",
+    });
+
+    expect(result.updated).toBe(true);
+    expect(result.content).toContain("**DevContainer**");
+    expect(result.content).toContain("Docker 開発環境");
+    expect(result.content).not.toContain("Old content");
+  });
+
+  it("FILES マーカー間のコンテンツを更新する", async () => {
+    const readme = `# My Project
+
+<!-- FILES:START -->
+Old files
+<!-- FILES:END -->`;
+
+    const modulesJson = JSON.stringify({
+      modules: [
+        {
+          id: ".devcontainer",
+          name: "DevContainer",
+          description: "Docker 開発環境",
+          patterns: [".devcontainer/devcontainer.json"],
+        },
+      ],
+    });
+
+    vol.fromJSON({
+      "/project/README.md": readme,
+      "/project/.devenv/modules.jsonc": modulesJson,
+    });
+
+    const result = await generateReadme({
+      readmePath: "/project/README.md",
+      modulesPath: "/project/.devenv/modules.jsonc",
+    });
+
+    expect(result.updated).toBe(true);
+    expect(result.content).toContain(".devcontainer/devcontainer.json");
+    expect(result.content).not.toContain("Old files");
+  });
+
+  it("modules.jsonc が存在しない場合は空のモジュールリストとして扱う", async () => {
+    const readme = `# My Project
+
+<!-- FEATURES:START -->
+Old content
+<!-- FEATURES:END -->`;
+
+    vol.fromJSON({
+      "/project/README.md": readme,
+    });
+
+    const result = await generateReadme({
+      readmePath: "/project/README.md",
+      modulesPath: "/project/.devenv/modules.jsonc",
+    });
+
+    // モジュールがないので更新されない
+    expect(result.updated).toBe(false);
+  });
+
+  it("COMMANDS マーカーをカスタム関数で更新する", async () => {
+    const readme = `# My Project
+
+<!-- COMMANDS:START -->
+Old commands
+<!-- COMMANDS:END -->`;
+
+    vol.fromJSON({
+      "/project/README.md": readme,
+      "/project/.devenv/modules.jsonc": JSON.stringify({ modules: [] }),
+    });
+
+    const result = await generateReadme({
+      readmePath: "/project/README.md",
+      modulesPath: "/project/.devenv/modules.jsonc",
+      generateCommandsSection: async () => "## Commands\n\n- `pnpm dev`\n",
+    });
+
+    expect(result.updated).toBe(true);
+    expect(result.content).toContain("pnpm dev");
+    expect(result.content).not.toContain("Old commands");
+  });
+
+  it("複数のマーカーを同時に更新できる", async () => {
+    const readme = `# My Project
+
+<!-- FEATURES:START -->
+Old features
+<!-- FEATURES:END -->
+
+Some text
+
+<!-- FILES:START -->
+Old files
+<!-- FILES:END -->`;
+
+    const modulesJson = JSON.stringify({
+      modules: [
+        {
+          id: ".",
+          name: "ルート設定",
+          description: "ルート設定ファイル",
+          patterns: [".mcp.json"],
+        },
+      ],
+    });
+
+    vol.fromJSON({
+      "/project/README.md": readme,
+      "/project/.devenv/modules.jsonc": modulesJson,
+    });
+
+    const result = await generateReadme({
+      readmePath: "/project/README.md",
+      modulesPath: "/project/.devenv/modules.jsonc",
+    });
+
+    expect(result.updated).toBe(true);
+    expect(result.content).toContain("**ルート設定**");
+    expect(result.content).toContain(".mcp.json");
+  });
+
+  it("glob パターンを持つファイルに (パターン) ラベルを付ける", async () => {
+    const readme = `# My Project
+
+<!-- FILES:START -->
+<!-- FILES:END -->`;
+
+    const modulesJson = JSON.stringify({
+      modules: [
+        {
+          id: ".devcontainer",
+          name: "DevContainer",
+          description: "Docker 開発環境",
+          patterns: [".devcontainer/*.sh"],
+        },
+      ],
+    });
+
+    vol.fromJSON({
+      "/project/README.md": readme,
+      "/project/.devenv/modules.jsonc": modulesJson,
+    });
+
+    const result = await generateReadme({
+      readmePath: "/project/README.md",
+      modulesPath: "/project/.devenv/modules.jsonc",
+    });
+
+    expect(result.content).toContain("(パターン)");
+  });
+});
+
+describe("updateReadmeFile", () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it("更新があればファイルに書き込む", async () => {
+    const readme = `# My Project
+
+<!-- FEATURES:START -->
+<!-- FEATURES:END -->`;
+
+    const modulesJson = JSON.stringify({
+      modules: [
+        { id: ".", name: "Root", description: "ルート設定", patterns: [] },
+      ],
+    });
+
+    vol.fromJSON({
+      "/project/README.md": readme,
+      "/project/.devenv/modules.jsonc": modulesJson,
+    });
+
+    const result = await updateReadmeFile({
+      readmePath: "/project/README.md",
+      modulesPath: "/project/.devenv/modules.jsonc",
+    });
+
+    expect(result.updated).toBe(true);
+
+    const savedContent = vol.readFileSync("/project/README.md", "utf8");
+    expect(savedContent).toContain("**Root**");
+  });
+
+  it("更新がなければファイルに書き込まない", async () => {
+    const readme = "# My Project\n\nNo markers here";
+
+    vol.fromJSON({
+      "/project/README.md": readme,
+      "/project/.devenv/modules.jsonc": JSON.stringify({ modules: [] }),
+    });
+
+    await updateReadmeFile({
+      readmePath: "/project/README.md",
+      modulesPath: "/project/.devenv/modules.jsonc",
+    });
+
+    const savedContent = vol.readFileSync("/project/README.md", "utf8");
+    expect(savedContent).toBe(readme);
+  });
+});
+
+describe("detectAndUpdateReadme", () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it("README が存在しない場合は null を返す", async () => {
+    vol.fromJSON({});
+
+    const result = await detectAndUpdateReadme("/project", "/template");
+
+    expect(result).toBeNull();
+  });
+
+  it("マーカーがない README の場合は null を返す", async () => {
+    vol.fromJSON({
+      "/project/README.md": "# My Project\n\nNo markers",
+    });
+
+    const result = await detectAndUpdateReadme("/project", "/template");
+
+    expect(result).toBeNull();
+  });
+
+  it("FEATURES マーカーがあれば更新する", async () => {
+    vol.fromJSON({
+      "/project/README.md": "# My Project\n\n<!-- FEATURES:START -->\n<!-- FEATURES:END -->",
+      "/template/.devenv/modules.jsonc": JSON.stringify({
+        modules: [{ id: ".", name: "Root", description: "Test", patterns: [] }],
+      }),
+    });
+
+    const result = await detectAndUpdateReadme("/project", "/template");
+
+    expect(result).not.toBeNull();
+    expect(result?.updated).toBe(true);
+  });
+
+  it("FILES マーカーがあれば更新する", async () => {
+    vol.fromJSON({
+      "/project/README.md": "# My Project\n\n<!-- FILES:START -->\n<!-- FILES:END -->",
+      "/template/.devenv/modules.jsonc": JSON.stringify({
+        modules: [{ id: ".", name: "Root", description: "Test", patterns: [".mcp.json"] }],
+      }),
+    });
+
+    const result = await detectAndUpdateReadme("/project", "/template");
+
+    expect(result).not.toBeNull();
+    expect(result?.updated).toBe(true);
+  });
+});

--- a/packages/create-devenv/src/utils/__tests__/untracked.test.ts
+++ b/packages/create-devenv/src/utils/__tests__/untracked.test.ts
@@ -1,0 +1,159 @@
+import { vol } from "memfs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// fs モジュールをモック
+vi.mock("node:fs", async () => {
+  const memfs = await import("memfs");
+  return memfs.fs;
+});
+
+vi.mock("node:fs/promises", async () => {
+  const memfs = await import("memfs");
+  return memfs.fs.promises;
+});
+
+// 純粋関数をインポート
+import {
+  getModuleIdFromPath,
+  getDisplayFolder,
+  getModuleBaseDir,
+  getTotalUntrackedCount,
+} from "../untracked";
+
+describe("getModuleIdFromPath", () => {
+  it("ルート直下のファイルは '.' を返す", () => {
+    expect(getModuleIdFromPath(".mcp.json")).toBe(".");
+    expect(getModuleIdFromPath(".mise.toml")).toBe(".");
+    expect(getModuleIdFromPath("readme.md")).toBe(".");
+  });
+
+  it(".devcontainer 配下のファイルは '.devcontainer' を返す", () => {
+    expect(getModuleIdFromPath(".devcontainer/devcontainer.json")).toBe(".devcontainer");
+    expect(getModuleIdFromPath(".devcontainer/setup.sh")).toBe(".devcontainer");
+  });
+
+  it(".github 配下のファイルは '.github' を返す", () => {
+    expect(getModuleIdFromPath(".github/workflows/ci.yml")).toBe(".github");
+    expect(getModuleIdFromPath(".github/labeler.yml")).toBe(".github");
+  });
+
+  it(".claude 配下のファイルは '.claude' を返す", () => {
+    expect(getModuleIdFromPath(".claude/settings.json")).toBe(".claude");
+  });
+
+  it("深いネストのファイルは最初のディレクトリを返す", () => {
+    expect(getModuleIdFromPath(".github/workflows/deep/nested/file.yml")).toBe(".github");
+  });
+});
+
+describe("getDisplayFolder", () => {
+  it("'.' を 'root' として表示する", () => {
+    expect(getDisplayFolder(".")).toBe("root");
+  });
+
+  it("その他のモジュール ID はそのまま返す", () => {
+    expect(getDisplayFolder(".devcontainer")).toBe(".devcontainer");
+    expect(getDisplayFolder(".github")).toBe(".github");
+    expect(getDisplayFolder(".claude")).toBe(".claude");
+  });
+});
+
+describe("getModuleBaseDir", () => {
+  it("'.' の場合は null を返す", () => {
+    expect(getModuleBaseDir(".")).toBeNull();
+  });
+
+  it("その他のモジュール ID はそのまま返す", () => {
+    expect(getModuleBaseDir(".devcontainer")).toBe(".devcontainer");
+    expect(getModuleBaseDir(".github")).toBe(".github");
+    expect(getModuleBaseDir(".claude")).toBe(".claude");
+  });
+});
+
+describe("getTotalUntrackedCount", () => {
+  it("全フォルダの未追跡ファイル数を合計する", () => {
+    const untrackedByFolder = [
+      {
+        folder: ".devcontainer",
+        files: [
+          { path: ".devcontainer/new.sh", folder: ".devcontainer", moduleId: ".devcontainer" },
+          { path: ".devcontainer/test.sh", folder: ".devcontainer", moduleId: ".devcontainer" },
+        ],
+      },
+      {
+        folder: ".github",
+        files: [{ path: ".github/new.yml", folder: ".github", moduleId: ".github" }],
+      },
+    ];
+
+    expect(getTotalUntrackedCount(untrackedByFolder)).toBe(3);
+  });
+
+  it("空のリストの場合は 0 を返す", () => {
+    expect(getTotalUntrackedCount([])).toBe(0);
+  });
+
+  it("ファイルのないフォルダは 0 としてカウント", () => {
+    const untrackedByFolder = [
+      { folder: ".devcontainer", files: [] },
+      {
+        folder: ".github",
+        files: [{ path: ".github/new.yml", folder: ".github", moduleId: ".github" }],
+      },
+    ];
+
+    expect(getTotalUntrackedCount(untrackedByFolder)).toBe(1);
+  });
+});
+
+describe("loadAllGitignores", () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  // loadAllGitignores のテストは ignore ライブラリの動作に依存するため、
+  // 統合テストとしてテストする
+
+  it("ルートの .gitignore を読み込む", async () => {
+    vol.fromJSON({
+      "/project/.gitignore": "node_modules/\n*.log",
+    });
+
+    const { loadAllGitignores } = await import("../untracked");
+    const ig = await loadAllGitignores("/project", []);
+
+    expect(ig.ignores("node_modules/package.json")).toBe(true);
+    expect(ig.ignores("error.log")).toBe(true);
+    expect(ig.ignores("file.txt")).toBe(false);
+  });
+
+  it(".gitignore が存在しない場合も動作する", async () => {
+    vol.fromJSON({
+      "/project": null,
+    });
+
+    const { loadAllGitignores } = await import("../untracked");
+    const ig = await loadAllGitignores("/project", []);
+
+    // 何も無視しない
+    expect(ig.ignores("file.txt")).toBe(false);
+  });
+
+  it("サブディレクトリの .gitignore を読み込む", async () => {
+    vol.fromJSON({
+      "/project/.gitignore": "*.log",
+      "/project/.devcontainer/.gitignore": "*.local",
+    });
+
+    const { loadAllGitignores } = await import("../untracked");
+    const ig = await loadAllGitignores("/project", [".devcontainer"]);
+
+    expect(ig.ignores("error.log")).toBe(true);
+    expect(ig.ignores(".devcontainer/config.local")).toBe(true);
+    expect(ig.ignores("config.local")).toBe(false); // サブディレクトリ外は適用されない
+  });
+});
+
+// getAllFilesInDirs と getRootDotFiles は tinyglobby に依存するため、
+// 統合テストとしてテストするか、別途モックを用意する必要があります。
+// ここでは純粋関数のみをテストしています。


### PR DESCRIPTION
Add comprehensive tests for:
- config.ts: Config file read/write operations
- patterns.ts: Pattern matching and merging utilities
- modules/schemas.ts: Zod schema validation
- modules/loader.ts: modules.jsonc loader
- modules/index.ts: Module helper functions
- untracked.ts: Untracked file detection
- readme.ts: README generation
- diff-viewer.ts: Diff display components
- github.ts: GitHub API integration

Test count: 40 → 209 (+169 tests)