### PR TITLE
Expand tests for create-devenv package

### DIFF
--- a/packages/create-devenv/src/commands/__tests__/diff.test.ts
+++ b/packages/create-devenv/src/commands/__tests__/diff.test.ts
@@ -1,6 +1,5 @@
 import { vol } from "memfs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { DiffResult } from "../../modules/schemas";
 
 // fs モジュールをモック
 vi.mock("node:fs", async () => {
@@ -72,11 +71,9 @@ const validConfig = {
   },
 };
 
-const emptyDiff: DiffResult = {
-  added: [],
-  modified: [],
-  deleted: [],
-  unchanged: [],
+const emptyDiff = {
+  files: [],
+  summary: { added: 0, modified: 0, deleted: 0, unchanged: 0 },
 };
 
 describe("diffCommand", () => {
@@ -94,18 +91,23 @@ describe("diffCommand", () => {
 
   describe("meta", () => {
     it("コマンドメタデータが正しい", () => {
-      expect(diffCommand.meta?.name).toBe("diff");
-      expect(diffCommand.meta?.description).toBe("Show differences between local and template");
+      // citty の型は Resolvable なので直接アクセスできる
+      expect((diffCommand.meta as { name: string }).name).toBe("diff");
+      expect((diffCommand.meta as { description: string }).description).toBe(
+        "Show differences between local and template",
+      );
     });
   });
 
   describe("args", () => {
     it("dir 引数のデフォルト値は '.'", () => {
-      expect(diffCommand.args?.dir?.default).toBe(".");
+      const args = diffCommand.args as { dir: { default: string } };
+      expect(args.dir.default).toBe(".");
     });
 
     it("verbose 引数のデフォルト値は false", () => {
-      expect(diffCommand.args?.verbose?.default).toBe(false);
+      const args = diffCommand.args as { verbose: { default: boolean } };
+      expect(args.verbose.default).toBe(false);
     });
   });
 
@@ -116,7 +118,7 @@ describe("diffCommand", () => {
       });
 
       await expect(
-        diffCommand.run?.({
+        (diffCommand.run as any)({
           args: { dir: "/test", verbose: false },
           rawArgs: [],
           cmd: diffCommand,
@@ -134,7 +136,7 @@ describe("diffCommand", () => {
       });
 
       await expect(
-        diffCommand.run?.({
+        (diffCommand.run as any)({
           args: { dir: "/test", verbose: false },
           rawArgs: [],
           cmd: diffCommand,
@@ -152,7 +154,7 @@ describe("diffCommand", () => {
         }),
       });
 
-      await diffCommand.run?.({
+      await (diffCommand.run as any)({
         args: { dir: "/test", verbose: false },
         rawArgs: [],
         cmd: diffCommand,
@@ -169,7 +171,7 @@ describe("diffCommand", () => {
       mockDetectDiff.mockResolvedValueOnce(emptyDiff);
       mockHasDiff.mockReturnValueOnce(false);
 
-      await diffCommand.run?.({
+      await (diffCommand.run as any)({
         args: { dir: "/test", verbose: false },
         rawArgs: [],
         cmd: diffCommand,
@@ -184,24 +186,21 @@ describe("diffCommand", () => {
         "/test/.devenv.json": JSON.stringify(validConfig),
       });
 
-      const diffWithChanges: DiffResult = {
-        added: [
+      const diffWithChanges = {
+        files: [
           {
             path: "new-file.txt",
-            type: "added",
+            type: "added" as const,
             localContent: "content",
-            templateContent: null,
           },
         ],
-        modified: [],
-        deleted: [],
-        unchanged: [],
+        summary: { added: 1, modified: 0, deleted: 0, unchanged: 0 },
       };
 
       mockDetectDiff.mockResolvedValueOnce(diffWithChanges);
       mockHasDiff.mockReturnValueOnce(true);
 
-      await diffCommand.run?.({
+      await (diffCommand.run as any)({
         args: { dir: "/test", verbose: false },
         rawArgs: [],
         cmd: diffCommand,
@@ -219,7 +218,7 @@ describe("diffCommand", () => {
       mockDetectDiff.mockResolvedValueOnce(emptyDiff);
       mockHasDiff.mockReturnValueOnce(false);
 
-      await diffCommand.run?.({
+      await (diffCommand.run as any)({
         args: { dir: "/test", verbose: false },
         rawArgs: [],
         cmd: diffCommand,
@@ -238,7 +237,7 @@ describe("diffCommand", () => {
       mockDetectDiff.mockRejectedValueOnce(new Error("Diff error"));
 
       await expect(
-        diffCommand.run?.({
+        (diffCommand.run as any)({
           args: { dir: "/test", verbose: false },
           rawArgs: [],
           cmd: diffCommand,

--- a/packages/create-devenv/src/commands/__tests__/diff.test.ts
+++ b/packages/create-devenv/src/commands/__tests__/diff.test.ts
@@ -1,0 +1,249 @@
+import { vol } from "memfs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DiffResult } from "../../modules/schemas";
+
+// fs モジュールをモック
+vi.mock("node:fs", async () => {
+  const memfs = await import("memfs");
+  return memfs.fs;
+});
+
+vi.mock("node:fs/promises", async () => {
+  const memfs = await import("memfs");
+  return memfs.fs.promises;
+});
+
+// giget をモック
+vi.mock("giget", () => ({
+  downloadTemplate: vi.fn(),
+}));
+
+// utils/diff をモック
+vi.mock("../../utils/diff", () => ({
+  detectDiff: vi.fn(),
+  formatDiff: vi.fn(() => "formatted diff output"),
+  hasDiff: vi.fn(),
+}));
+
+// utils/ui をモック
+vi.mock("../../utils/ui", () => ({
+  showHeader: vi.fn(),
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    dim: vi.fn(),
+    newline: vi.fn(),
+    error: vi.fn(),
+  },
+  step: vi.fn(),
+  withSpinner: vi.fn(async (_text: string, fn: () => Promise<unknown>) => fn()),
+  diffHeader: vi.fn(),
+  box: vi.fn(),
+  showNextSteps: vi.fn(),
+}));
+
+// console.log をモック
+vi.spyOn(console, "log").mockImplementation(() => {});
+
+// process.exit をモック
+const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+  throw new Error("process.exit called");
+});
+
+// モック後にインポート
+const { diffCommand } = await import("../diff");
+const { downloadTemplate } = await import("giget");
+const { detectDiff, hasDiff } = await import("../../utils/diff");
+const { log, box } = await import("../../utils/ui");
+
+const mockDownloadTemplate = vi.mocked(downloadTemplate);
+const mockDetectDiff = vi.mocked(detectDiff);
+const mockHasDiff = vi.mocked(hasDiff);
+const mockLog = vi.mocked(log);
+const mockBox = vi.mocked(box);
+
+const validConfig = {
+  version: "0.1.0",
+  installedAt: "2024-01-01T00:00:00.000Z",
+  modules: ["root", "github"],
+  source: {
+    owner: "tktcorporation",
+    repo: ".github",
+  },
+};
+
+const emptyDiff: DiffResult = {
+  added: [],
+  modified: [],
+  deleted: [],
+  unchanged: [],
+};
+
+describe("diffCommand", () => {
+  beforeEach(() => {
+    vol.reset();
+    vi.clearAllMocks();
+    mockExit.mockClear();
+
+    // デフォルトのモック設定
+    mockDownloadTemplate.mockResolvedValue({
+      dir: "/tmp/template",
+      source: "gh:tktcorporation/.github",
+    });
+  });
+
+  describe("meta", () => {
+    it("コマンドメタデータが正しい", () => {
+      expect(diffCommand.meta?.name).toBe("diff");
+      expect(diffCommand.meta?.description).toBe("Show differences between local and template");
+    });
+  });
+
+  describe("args", () => {
+    it("dir 引数のデフォルト値は '.'", () => {
+      expect(diffCommand.args?.dir?.default).toBe(".");
+    });
+
+    it("verbose 引数のデフォルト値は false", () => {
+      expect(diffCommand.args?.verbose?.default).toBe(false);
+    });
+  });
+
+  describe("run", () => {
+    it(".devenv.json が存在しない場合はエラー", async () => {
+      vol.fromJSON({
+        "/test": null,
+      });
+
+      await expect(
+        diffCommand.run?.({
+          args: { dir: "/test", verbose: false },
+          rawArgs: [],
+          cmd: diffCommand,
+        }),
+      ).rejects.toThrow("process.exit called");
+
+      expect(mockLog.error).toHaveBeenCalledWith(
+        ".devenv.json not found. Run 'init' command first.",
+      );
+    });
+
+    it("無効な .devenv.json 形式の場合はエラー", async () => {
+      vol.fromJSON({
+        "/test/.devenv.json": JSON.stringify({ invalid: "format" }),
+      });
+
+      await expect(
+        diffCommand.run?.({
+          args: { dir: "/test", verbose: false },
+          rawArgs: [],
+          cmd: diffCommand,
+        }),
+      ).rejects.toThrow("process.exit called");
+
+      expect(mockLog.error).toHaveBeenCalledWith("Invalid .devenv.json format");
+    });
+
+    it("modules が空の場合は警告", async () => {
+      vol.fromJSON({
+        "/test/.devenv.json": JSON.stringify({
+          ...validConfig,
+          modules: [],
+        }),
+      });
+
+      await diffCommand.run?.({
+        args: { dir: "/test", verbose: false },
+        rawArgs: [],
+        cmd: diffCommand,
+      });
+
+      expect(mockLog.warn).toHaveBeenCalledWith("No modules installed");
+    });
+
+    it("差分がない場合は成功メッセージ", async () => {
+      vol.fromJSON({
+        "/test/.devenv.json": JSON.stringify(validConfig),
+      });
+
+      mockDetectDiff.mockResolvedValueOnce(emptyDiff);
+      mockHasDiff.mockReturnValueOnce(false);
+
+      await diffCommand.run?.({
+        args: { dir: "/test", verbose: false },
+        rawArgs: [],
+        cmd: diffCommand,
+      });
+
+      expect(mockBox).toHaveBeenCalledWith("No changes", "success");
+      expect(mockLog.info).toHaveBeenCalledWith("Your local files are in sync with the template");
+    });
+
+    it("差分がある場合は差分を表示", async () => {
+      vol.fromJSON({
+        "/test/.devenv.json": JSON.stringify(validConfig),
+      });
+
+      const diffWithChanges: DiffResult = {
+        added: [
+          {
+            path: "new-file.txt",
+            type: "added",
+            localContent: "content",
+            templateContent: null,
+          },
+        ],
+        modified: [],
+        deleted: [],
+        unchanged: [],
+      };
+
+      mockDetectDiff.mockResolvedValueOnce(diffWithChanges);
+      mockHasDiff.mockReturnValueOnce(true);
+
+      await diffCommand.run?.({
+        args: { dir: "/test", verbose: false },
+        rawArgs: [],
+        cmd: diffCommand,
+      });
+
+      expect(mockBox).not.toHaveBeenCalledWith("No changes", "success");
+    });
+
+    it("一時ディレクトリを削除", async () => {
+      vol.fromJSON({
+        "/test/.devenv.json": JSON.stringify(validConfig),
+        "/test/.devenv-temp": null,
+      });
+
+      mockDetectDiff.mockResolvedValueOnce(emptyDiff);
+      mockHasDiff.mockReturnValueOnce(false);
+
+      await diffCommand.run?.({
+        args: { dir: "/test", verbose: false },
+        rawArgs: [],
+        cmd: diffCommand,
+      });
+
+      // 一時ディレクトリが削除される（memfs では確認が難しいのでモックで確認）
+      expect(mockDownloadTemplate).toHaveBeenCalled();
+    });
+
+    it("エラー時も一時ディレクトリを削除", async () => {
+      vol.fromJSON({
+        "/test/.devenv.json": JSON.stringify(validConfig),
+        "/test/.devenv-temp": null,
+      });
+
+      mockDetectDiff.mockRejectedValueOnce(new Error("Diff error"));
+
+      await expect(
+        diffCommand.run?.({
+          args: { dir: "/test", verbose: false },
+          rawArgs: [],
+          cmd: diffCommand,
+        }),
+      ).rejects.toThrow("Diff error");
+    });
+  });
+});

--- a/packages/create-devenv/src/commands/__tests__/init.test.ts
+++ b/packages/create-devenv/src/commands/__tests__/init.test.ts
@@ -88,22 +88,27 @@ describe("initCommand", () => {
 
   describe("meta", () => {
     it("コマンドメタデータが正しい", () => {
-      expect(initCommand.meta?.name).toBe("create-devenv");
-      expect(initCommand.meta?.description).toBe("Apply dev environment template to your project");
+      expect((initCommand.meta as { name: string }).name).toBe("create-devenv");
+      expect((initCommand.meta as { description: string }).description).toBe(
+        "Apply dev environment template to your project",
+      );
     });
   });
 
   describe("args", () => {
     it("dir 引数のデフォルト値は '.'", () => {
-      expect(initCommand.args?.dir?.default).toBe(".");
+      const args = initCommand.args as { dir: { default: string } };
+      expect(args.dir.default).toBe(".");
     });
 
     it("force 引数のデフォルト値は false", () => {
-      expect(initCommand.args?.force?.default).toBe(false);
+      const args = initCommand.args as { force: { default: boolean } };
+      expect(args.force.default).toBe(false);
     });
 
     it("yes 引数のデフォルト値は false", () => {
-      expect(initCommand.args?.yes?.default).toBe(false);
+      const args = initCommand.args as { yes: { default: boolean } };
+      expect(args.yes.default).toBe(false);
     });
   });
 
@@ -118,7 +123,7 @@ describe("initCommand", () => {
         overwriteStrategy: "prompt",
       });
 
-      await initCommand.run?.({
+      await (initCommand.run as any)({
         args: { dir: "/test", force: false, yes: false },
         rawArgs: [],
         cmd: initCommand,
@@ -134,7 +139,7 @@ describe("initCommand", () => {
 
       mockFetchTemplates.mockResolvedValue([{ action: "copied", path: ".mcp.json" }]);
 
-      await initCommand.run?.({
+      await (initCommand.run as any)({
         args: { dir: "/test", force: false, yes: true },
         rawArgs: [],
         cmd: initCommand,
@@ -156,7 +161,7 @@ describe("initCommand", () => {
 
       mockFetchTemplates.mockResolvedValue([{ action: "copied", path: ".mcp.json" }]);
 
-      await initCommand.run?.({
+      await (initCommand.run as any)({
         args: { dir: "/new-dir", force: false, yes: false },
         rawArgs: [],
         cmd: initCommand,
@@ -177,7 +182,7 @@ describe("initCommand", () => {
 
       mockFetchTemplates.mockResolvedValue([]);
 
-      await initCommand.run?.({
+      await (initCommand.run as any)({
         args: { dir: "/test", force: false, yes: false },
         rawArgs: [],
         cmd: initCommand,
@@ -203,7 +208,7 @@ describe("initCommand", () => {
 
       mockFetchTemplates.mockResolvedValue([]);
 
-      await initCommand.run?.({
+      await (initCommand.run as any)({
         args: { dir: "/test", force: true, yes: false }, // --force
         rawArgs: [],
         cmd: initCommand,
@@ -235,7 +240,7 @@ describe("initCommand", () => {
 
       mockFetchTemplates.mockResolvedValue([]);
 
-      await initCommand.run?.({
+      await (initCommand.run as any)({
         args: { dir: "/test", force: false, yes: false },
         rawArgs: [],
         cmd: initCommand,
@@ -258,7 +263,7 @@ describe("initCommand", () => {
       mockPromptInit.mockRejectedValueOnce(new Error("User cancelled"));
 
       await expect(
-        initCommand.run?.({
+        (initCommand.run as any)({
           args: { dir: "/test", force: false, yes: false },
           rawArgs: [],
           cmd: initCommand,
@@ -278,7 +283,7 @@ describe("initCommand", () => {
         overwriteStrategy: "prompt",
       });
 
-      await initCommand.run?.({
+      await (initCommand.run as any)({
         args: { dir: "init", force: false, yes: false },
         rawArgs: [],
         cmd: initCommand,

--- a/packages/create-devenv/src/commands/__tests__/init.test.ts
+++ b/packages/create-devenv/src/commands/__tests__/init.test.ts
@@ -1,6 +1,5 @@
 import { vol } from "memfs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { TemplateModule } from "../../modules/schemas";
 
 // fs モジュールをモック
 vi.mock("node:fs", async () => {
@@ -69,21 +68,6 @@ const mockFetchTemplates = vi.mocked(fetchTemplates);
 const mockWriteFileWithStrategy = vi.mocked(writeFileWithStrategy);
 const mockPromptInit = vi.mocked(promptInit);
 const mockLog = vi.mocked(log);
-
-const testModules: TemplateModule[] = [
-  {
-    id: "root",
-    name: "Root Config",
-    description: "Root configuration files",
-    patterns: [".mcp.json"],
-  },
-  {
-    id: "devcontainer",
-    name: "Dev Container",
-    description: "Docker dev environment",
-    patterns: [".devcontainer/**"],
-  },
-];
 
 describe("initCommand", () => {
   beforeEach(() => {

--- a/packages/create-devenv/src/commands/__tests__/init.test.ts
+++ b/packages/create-devenv/src/commands/__tests__/init.test.ts
@@ -1,0 +1,307 @@
+import { vol } from "memfs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TemplateModule } from "../../modules/schemas";
+
+// fs モジュールをモック
+vi.mock("node:fs", async () => {
+  const memfs = await import("memfs");
+  return memfs.fs;
+});
+
+vi.mock("node:fs/promises", async () => {
+  const memfs = await import("memfs");
+  return memfs.fs.promises;
+});
+
+// 外部依存をモック
+vi.mock("../../utils/template", () => ({
+  downloadTemplateToTemp: vi.fn(),
+  fetchTemplates: vi.fn(),
+  writeFileWithStrategy: vi.fn(),
+}));
+
+vi.mock("../../prompts/init", () => ({
+  promptInit: vi.fn(),
+}));
+
+vi.mock("../../utils/ui", () => ({
+  showHeader: vi.fn(),
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    dim: vi.fn(),
+    newline: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+  pc: {
+    cyan: (s: string) => s,
+    bold: (s: string) => s,
+    dim: (s: string) => s,
+  },
+  step: vi.fn(),
+  withSpinner: vi.fn(async (_text: string, fn: () => Promise<unknown>) => fn()),
+  logFileResult: vi.fn(),
+  calculateSummary: vi.fn(() => ({ added: 1, updated: 0, skipped: 0 })),
+  showSummary: vi.fn(),
+  box: vi.fn(),
+  showNextSteps: vi.fn(),
+}));
+
+vi.mock("../../modules/index", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../modules/index")>();
+  return {
+    ...original,
+    modulesFileExists: vi.fn(() => false),
+    loadModulesFile: vi.fn(),
+  };
+});
+
+// モック後にインポート
+const { initCommand } = await import("../init");
+const { downloadTemplateToTemp, fetchTemplates, writeFileWithStrategy } =
+  await import("../../utils/template");
+const { promptInit } = await import("../../prompts/init");
+const { log } = await import("../../utils/ui");
+
+const mockDownloadTemplateToTemp = vi.mocked(downloadTemplateToTemp);
+const mockFetchTemplates = vi.mocked(fetchTemplates);
+const mockWriteFileWithStrategy = vi.mocked(writeFileWithStrategy);
+const mockPromptInit = vi.mocked(promptInit);
+const mockLog = vi.mocked(log);
+
+const testModules: TemplateModule[] = [
+  {
+    id: "root",
+    name: "Root Config",
+    description: "Root configuration files",
+    patterns: [".mcp.json"],
+  },
+  {
+    id: "devcontainer",
+    name: "Dev Container",
+    description: "Docker dev environment",
+    patterns: [".devcontainer/**"],
+  },
+];
+
+describe("initCommand", () => {
+  beforeEach(() => {
+    vol.reset();
+    vi.clearAllMocks();
+
+    // デフォルトのモック設定
+    mockDownloadTemplateToTemp.mockResolvedValue({
+      templateDir: "/tmp/template",
+      cleanup: vi.fn(),
+    });
+    mockFetchTemplates.mockResolvedValue([]);
+    mockWriteFileWithStrategy.mockResolvedValue({
+      action: "created",
+      path: ".devenv.json",
+    });
+  });
+
+  describe("meta", () => {
+    it("コマンドメタデータが正しい", () => {
+      expect(initCommand.meta?.name).toBe("create-devenv");
+      expect(initCommand.meta?.description).toBe("Apply dev environment template to your project");
+    });
+  });
+
+  describe("args", () => {
+    it("dir 引数のデフォルト値は '.'", () => {
+      expect(initCommand.args?.dir?.default).toBe(".");
+    });
+
+    it("force 引数のデフォルト値は false", () => {
+      expect(initCommand.args?.force?.default).toBe(false);
+    });
+
+    it("yes 引数のデフォルト値は false", () => {
+      expect(initCommand.args?.yes?.default).toBe(false);
+    });
+  });
+
+  describe("run", () => {
+    it("モジュールが選択されない場合は警告を表示", async () => {
+      vol.fromJSON({
+        "/test": null,
+      });
+
+      mockPromptInit.mockResolvedValueOnce({
+        modules: [],
+        overwriteStrategy: "prompt",
+      });
+
+      await initCommand.run?.({
+        args: { dir: "/test", force: false, yes: false },
+        rawArgs: [],
+        cmd: initCommand,
+      });
+
+      expect(mockLog.warn).toHaveBeenCalledWith("No modules selected");
+    });
+
+    it("--yes オプションで全モジュールを自動選択", async () => {
+      vol.fromJSON({
+        "/test": null,
+      });
+
+      mockFetchTemplates.mockResolvedValue([{ action: "copied", path: ".mcp.json" }]);
+
+      await initCommand.run?.({
+        args: { dir: "/test", force: false, yes: true },
+        rawArgs: [],
+        cmd: initCommand,
+      });
+
+      // promptInit は呼ばれない
+      expect(mockPromptInit).not.toHaveBeenCalled();
+      // fetchTemplates は呼ばれる
+      expect(mockFetchTemplates).toHaveBeenCalled();
+    });
+
+    it("ターゲットディレクトリが存在しない場合は作成", async () => {
+      vol.fromJSON({});
+
+      mockPromptInit.mockResolvedValueOnce({
+        modules: ["root"],
+        overwriteStrategy: "prompt",
+      });
+
+      mockFetchTemplates.mockResolvedValue([{ action: "copied", path: ".mcp.json" }]);
+
+      await initCommand.run?.({
+        args: { dir: "/new-dir", force: false, yes: false },
+        rawArgs: [],
+        cmd: initCommand,
+      });
+
+      expect(vol.existsSync("/new-dir")).toBe(true);
+    });
+
+    it("devcontainer モジュール選択時に env.example を作成", async () => {
+      vol.fromJSON({
+        "/test": null,
+      });
+
+      mockPromptInit.mockResolvedValueOnce({
+        modules: ["devcontainer"],
+        overwriteStrategy: "prompt",
+      });
+
+      mockFetchTemplates.mockResolvedValue([]);
+
+      await initCommand.run?.({
+        args: { dir: "/test", force: false, yes: false },
+        rawArgs: [],
+        cmd: initCommand,
+      });
+
+      // writeFileWithStrategy が devcontainer.env.example に対して呼ばれる
+      expect(mockWriteFileWithStrategy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          relativePath: ".devcontainer/devcontainer.env.example",
+        }),
+      );
+    });
+
+    it("--force オプションで overwrite 戦略を使用", async () => {
+      vol.fromJSON({
+        "/test": null,
+      });
+
+      mockPromptInit.mockResolvedValueOnce({
+        modules: ["root"],
+        overwriteStrategy: "prompt", // prompt を選択しても
+      });
+
+      mockFetchTemplates.mockResolvedValue([]);
+
+      await initCommand.run?.({
+        args: { dir: "/test", force: true, yes: false }, // --force
+        rawArgs: [],
+        cmd: initCommand,
+      });
+
+      // fetchTemplates は overwrite 戦略で呼ばれる
+      expect(mockFetchTemplates).toHaveBeenCalledWith(
+        expect.objectContaining({
+          overwriteStrategy: "overwrite",
+        }),
+      );
+    });
+
+    it("cleanup が必ず呼ばれる", async () => {
+      vol.fromJSON({
+        "/test": null,
+      });
+
+      const mockCleanup = vi.fn();
+      mockDownloadTemplateToTemp.mockResolvedValue({
+        templateDir: "/tmp/template",
+        cleanup: mockCleanup,
+      });
+
+      mockPromptInit.mockResolvedValueOnce({
+        modules: ["root"],
+        overwriteStrategy: "prompt",
+      });
+
+      mockFetchTemplates.mockResolvedValue([]);
+
+      await initCommand.run?.({
+        args: { dir: "/test", force: false, yes: false },
+        rawArgs: [],
+        cmd: initCommand,
+      });
+
+      expect(mockCleanup).toHaveBeenCalled();
+    });
+
+    it("エラー時も cleanup が呼ばれる", async () => {
+      vol.fromJSON({
+        "/test": null,
+      });
+
+      const mockCleanup = vi.fn();
+      mockDownloadTemplateToTemp.mockResolvedValue({
+        templateDir: "/tmp/template",
+        cleanup: mockCleanup,
+      });
+
+      mockPromptInit.mockRejectedValueOnce(new Error("User cancelled"));
+
+      await expect(
+        initCommand.run?.({
+          args: { dir: "/test", force: false, yes: false },
+          rawArgs: [],
+          cmd: initCommand,
+        }),
+      ).rejects.toThrow("User cancelled");
+
+      expect(mockCleanup).toHaveBeenCalled();
+    });
+
+    it("'init' 引数は無視して現在のディレクトリを使用", async () => {
+      vol.fromJSON({
+        ".": null,
+      });
+
+      mockPromptInit.mockResolvedValueOnce({
+        modules: [],
+        overwriteStrategy: "prompt",
+      });
+
+      await initCommand.run?.({
+        args: { dir: "init", force: false, yes: false },
+        rawArgs: [],
+        cmd: initCommand,
+      });
+
+      // "init" は "." として扱われる
+      expect(mockLog.info).toHaveBeenCalledWith(expect.stringContaining(process.cwd()));
+    });
+  });
+});

--- a/packages/create-devenv/src/commands/__tests__/push.test.ts
+++ b/packages/create-devenv/src/commands/__tests__/push.test.ts
@@ -1,0 +1,474 @@
+import { vol } from "memfs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DiffResult } from "../../modules/schemas";
+
+// fs モジュールをモック
+vi.mock("node:fs", async () => {
+  const memfs = await import("memfs");
+  return memfs.fs;
+});
+
+vi.mock("node:fs/promises", async () => {
+  const memfs = await import("memfs");
+  return memfs.fs.promises;
+});
+
+// giget をモック
+vi.mock("giget", () => ({
+  downloadTemplate: vi.fn(),
+}));
+
+// utils/diff をモック
+vi.mock("../../utils/diff", () => ({
+  detectDiff: vi.fn(),
+  formatDiff: vi.fn(() => "formatted diff output"),
+  getPushableFiles: vi.fn(() => []),
+}));
+
+// utils/github をモック
+vi.mock("../../utils/github", () => ({
+  getGitHubToken: vi.fn(),
+  createPullRequest: vi.fn(),
+}));
+
+// utils/readme をモック
+vi.mock("../../utils/readme", () => ({
+  detectAndUpdateReadme: vi.fn(() => null),
+}));
+
+// utils/untracked をモック
+vi.mock("../../utils/untracked", () => ({
+  detectUntrackedFiles: vi.fn(() => []),
+}));
+
+// prompts/push をモック
+vi.mock("../../prompts/push", () => ({
+  promptPushConfirm: vi.fn(),
+  promptGitHubToken: vi.fn(),
+  promptPrTitle: vi.fn(),
+  promptPrBody: vi.fn(),
+  promptSelectFilesWithDiff: vi.fn(),
+  promptAddUntrackedFiles: vi.fn(() => []),
+}));
+
+// modules をモック
+vi.mock("../../modules", () => ({
+  defaultModules: [],
+  modulesFileExists: vi.fn(() => false),
+  loadModulesFile: vi.fn(),
+  addPatternToModulesFile: vi.fn(),
+}));
+
+// utils/ui をモック
+vi.mock("../../utils/ui", () => ({
+  showHeader: vi.fn(),
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    dim: vi.fn(),
+    newline: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+  pc: {
+    cyan: (s: string) => s,
+    bold: (s: string) => s,
+    dim: (s: string) => s,
+    green: (s: string) => s,
+  },
+  step: vi.fn(),
+  withSpinner: vi.fn(async (_text: string, fn: () => Promise<unknown>) => fn()),
+  diffHeader: vi.fn(),
+  box: vi.fn(),
+  showNextSteps: vi.fn(),
+}));
+
+// console.log をモック
+vi.spyOn(console, "log").mockImplementation(() => {});
+
+// process.exit をモック
+const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+  throw new Error("process.exit called");
+});
+
+// モック後にインポート
+const { pushCommand } = await import("../push");
+const { downloadTemplate } = await import("giget");
+const { detectDiff, getPushableFiles } = await import("../../utils/diff");
+const { getGitHubToken, createPullRequest } = await import("../../utils/github");
+const {
+  promptPushConfirm,
+  promptGitHubToken,
+  promptPrTitle,
+  promptPrBody,
+  promptSelectFilesWithDiff,
+} = await import("../../prompts/push");
+const { log, box } = await import("../../utils/ui");
+
+const mockDownloadTemplate = vi.mocked(downloadTemplate);
+const mockDetectDiff = vi.mocked(detectDiff);
+const mockGetPushableFiles = vi.mocked(getPushableFiles);
+const mockGetGitHubToken = vi.mocked(getGitHubToken);
+const mockCreatePullRequest = vi.mocked(createPullRequest);
+const mockPromptPushConfirm = vi.mocked(promptPushConfirm);
+const mockPromptGitHubToken = vi.mocked(promptGitHubToken);
+const mockPromptPrTitle = vi.mocked(promptPrTitle);
+const mockPromptPrBody = vi.mocked(promptPrBody);
+const mockPromptSelectFilesWithDiff = vi.mocked(promptSelectFilesWithDiff);
+const mockLog = vi.mocked(log);
+const mockBox = vi.mocked(box);
+
+const validConfig = {
+  version: "0.1.0",
+  installedAt: "2024-01-01T00:00:00.000Z",
+  modules: ["root", "github"],
+  source: {
+    owner: "tktcorporation",
+    repo: ".github",
+  },
+};
+
+const emptyDiff: DiffResult = {
+  added: [],
+  modified: [],
+  deleted: [],
+  unchanged: [],
+};
+
+describe("pushCommand", () => {
+  beforeEach(() => {
+    vol.reset();
+    vi.clearAllMocks();
+    mockExit.mockClear();
+
+    // デフォルトのモック設定
+    mockDownloadTemplate.mockResolvedValue({
+      dir: "/tmp/template",
+      source: "gh:tktcorporation/.github",
+    });
+    mockDetectDiff.mockResolvedValue(emptyDiff);
+    mockGetPushableFiles.mockReturnValue([]);
+  });
+
+  describe("meta", () => {
+    it("コマンドメタデータが正しい", () => {
+      expect(pushCommand.meta?.name).toBe("push");
+      expect(pushCommand.meta?.description).toBe(
+        "Push local changes to the template repository as a PR",
+      );
+    });
+  });
+
+  describe("args", () => {
+    it("dir 引数のデフォルト値は '.'", () => {
+      expect(pushCommand.args?.dir?.default).toBe(".");
+    });
+
+    it("dryRun 引数のデフォルト値は false", () => {
+      expect(pushCommand.args?.dryRun?.default).toBe(false);
+    });
+
+    it("force 引数のデフォルト値は false", () => {
+      expect(pushCommand.args?.force?.default).toBe(false);
+    });
+
+    it("interactive 引数のデフォルト値は true", () => {
+      expect(pushCommand.args?.interactive?.default).toBe(true);
+    });
+  });
+
+  describe("run", () => {
+    it(".devenv.json が存在しない場合はエラー", async () => {
+      vol.fromJSON({
+        "/test": null,
+      });
+
+      await expect(
+        pushCommand.run?.({
+          args: { dir: "/test", dryRun: false, force: false, interactive: true },
+          rawArgs: [],
+          cmd: pushCommand,
+        }),
+      ).rejects.toThrow("process.exit called");
+
+      expect(mockLog.error).toHaveBeenCalledWith(
+        ".devenv.json not found. Run 'init' command first.",
+      );
+    });
+
+    it("無効な .devenv.json 形式の場合はエラー", async () => {
+      vol.fromJSON({
+        "/test/.devenv.json": JSON.stringify({ invalid: "format" }),
+      });
+
+      await expect(
+        pushCommand.run?.({
+          args: { dir: "/test", dryRun: false, force: false, interactive: true },
+          rawArgs: [],
+          cmd: pushCommand,
+        }),
+      ).rejects.toThrow("process.exit called");
+
+      expect(mockLog.error).toHaveBeenCalledWith("Invalid .devenv.json format");
+    });
+
+    it("modules が空の場合は警告", async () => {
+      vol.fromJSON({
+        "/test/.devenv.json": JSON.stringify({
+          ...validConfig,
+          modules: [],
+        }),
+      });
+
+      await pushCommand.run?.({
+        args: { dir: "/test", dryRun: false, force: false, interactive: true },
+        rawArgs: [],
+        cmd: pushCommand,
+      });
+
+      expect(mockLog.warn).toHaveBeenCalledWith("No modules installed");
+    });
+
+    it("push 対象ファイルがない場合は情報メッセージ", async () => {
+      vol.fromJSON({
+        "/test/.devenv.json": JSON.stringify(validConfig),
+      });
+
+      mockGetPushableFiles.mockReturnValue([]);
+
+      await pushCommand.run?.({
+        args: { dir: "/test", dryRun: false, force: false, interactive: true },
+        rawArgs: [],
+        cmd: pushCommand,
+      });
+
+      expect(mockLog.info).toHaveBeenCalledWith("No changes to push");
+    });
+
+    it("--dry-run オプションで PR を作成しない", async () => {
+      vol.fromJSON({
+        "/test/.devenv.json": JSON.stringify(validConfig),
+      });
+
+      mockGetPushableFiles.mockReturnValue([
+        {
+          path: "file.txt",
+          type: "added",
+          localContent: "content",
+          templateContent: null,
+        },
+      ]);
+
+      await pushCommand.run?.({
+        args: { dir: "/test", dryRun: true, force: false, interactive: true },
+        rawArgs: [],
+        cmd: pushCommand,
+      });
+
+      expect(mockBox).toHaveBeenCalledWith("Dry run mode", "info");
+      expect(mockLog.info).toHaveBeenCalledWith("No PR was created (dry run)");
+      expect(mockCreatePullRequest).not.toHaveBeenCalled();
+    });
+
+    it("インタラクティブモードでファイル選択をキャンセル", async () => {
+      vol.fromJSON({
+        "/test/.devenv.json": JSON.stringify(validConfig),
+      });
+
+      mockGetPushableFiles.mockReturnValue([
+        {
+          path: "file.txt",
+          type: "added",
+          localContent: "content",
+          templateContent: null,
+        },
+      ]);
+
+      mockPromptSelectFilesWithDiff.mockResolvedValueOnce([]);
+
+      await pushCommand.run?.({
+        args: { dir: "/test", dryRun: false, force: false, interactive: true },
+        rawArgs: [],
+        cmd: pushCommand,
+      });
+
+      expect(mockLog.info).toHaveBeenCalledWith("No files selected. Cancelled.");
+      expect(mockCreatePullRequest).not.toHaveBeenCalled();
+    });
+
+    it("--no-interactive モードで確認をキャンセル", async () => {
+      vol.fromJSON({
+        "/test/.devenv.json": JSON.stringify(validConfig),
+      });
+
+      mockGetPushableFiles.mockReturnValue([
+        {
+          path: "file.txt",
+          type: "added",
+          localContent: "content",
+          templateContent: null,
+        },
+      ]);
+
+      mockPromptPushConfirm.mockResolvedValueOnce(false);
+
+      await pushCommand.run?.({
+        args: { dir: "/test", dryRun: false, force: false, interactive: false },
+        rawArgs: [],
+        cmd: pushCommand,
+      });
+
+      expect(mockLog.info).toHaveBeenCalledWith("Cancelled");
+      expect(mockCreatePullRequest).not.toHaveBeenCalled();
+    });
+
+    it("PR 作成成功", async () => {
+      vol.fromJSON({
+        "/test/.devenv.json": JSON.stringify(validConfig),
+      });
+
+      const pushableFile = {
+        path: "file.txt",
+        type: "added" as const,
+        localContent: "content",
+        templateContent: null,
+      };
+
+      mockGetPushableFiles.mockReturnValue([pushableFile]);
+      mockPromptSelectFilesWithDiff.mockResolvedValueOnce([pushableFile]);
+      mockGetGitHubToken.mockReturnValue("ghp_token");
+      mockPromptPrTitle.mockResolvedValueOnce("feat: add new file");
+      mockPromptPrBody.mockResolvedValueOnce("PR description");
+      mockCreatePullRequest.mockResolvedValueOnce({
+        url: "https://github.com/owner/repo/pull/1",
+        branch: "update-template-123",
+      });
+
+      await pushCommand.run?.({
+        args: { dir: "/test", dryRun: false, force: false, interactive: true },
+        rawArgs: [],
+        cmd: pushCommand,
+      });
+
+      expect(mockBox).toHaveBeenCalledWith("Pull request created!", "success");
+      expect(mockCreatePullRequest).toHaveBeenCalledWith(
+        "ghp_token",
+        expect.objectContaining({
+          owner: "tktcorporation",
+          repo: ".github",
+          title: "feat: add new file",
+          body: "PR description",
+        }),
+      );
+    });
+
+    it("GitHub トークンがない場合はプロンプト", async () => {
+      vol.fromJSON({
+        "/test/.devenv.json": JSON.stringify(validConfig),
+      });
+
+      const pushableFile = {
+        path: "file.txt",
+        type: "added" as const,
+        localContent: "content",
+        templateContent: null,
+      };
+
+      mockGetPushableFiles.mockReturnValue([pushableFile]);
+      mockPromptSelectFilesWithDiff.mockResolvedValueOnce([pushableFile]);
+      mockGetGitHubToken.mockReturnValue(undefined);
+      mockPromptGitHubToken.mockResolvedValueOnce("ghp_prompted_token");
+      mockPromptPrTitle.mockResolvedValueOnce("feat: add");
+      mockPromptPrBody.mockResolvedValueOnce(undefined);
+      mockCreatePullRequest.mockResolvedValueOnce({
+        url: "https://github.com/owner/repo/pull/1",
+        branch: "update-template-123",
+      });
+
+      await pushCommand.run?.({
+        args: { dir: "/test", dryRun: false, force: false, interactive: true },
+        rawArgs: [],
+        cmd: pushCommand,
+      });
+
+      expect(mockPromptGitHubToken).toHaveBeenCalled();
+      expect(mockCreatePullRequest).toHaveBeenCalledWith("ghp_prompted_token", expect.anything());
+    });
+
+    it("--message オプションで PR タイトルを指定", async () => {
+      vol.fromJSON({
+        "/test/.devenv.json": JSON.stringify(validConfig),
+      });
+
+      const pushableFile = {
+        path: "file.txt",
+        type: "added" as const,
+        localContent: "content",
+        templateContent: null,
+      };
+
+      mockGetPushableFiles.mockReturnValue([pushableFile]);
+      mockPromptSelectFilesWithDiff.mockResolvedValueOnce([pushableFile]);
+      mockGetGitHubToken.mockReturnValue("ghp_token");
+      mockPromptPrBody.mockResolvedValueOnce(undefined);
+      mockCreatePullRequest.mockResolvedValueOnce({
+        url: "https://github.com/owner/repo/pull/1",
+        branch: "update-template-123",
+      });
+
+      await pushCommand.run?.({
+        args: {
+          dir: "/test",
+          dryRun: false,
+          force: false,
+          interactive: true,
+          message: "Custom PR title",
+        },
+        rawArgs: [],
+        cmd: pushCommand,
+      });
+
+      // promptPrTitle は呼ばれない
+      expect(mockPromptPrTitle).not.toHaveBeenCalled();
+      expect(mockCreatePullRequest).toHaveBeenCalledWith(
+        "ghp_token",
+        expect.objectContaining({
+          title: "Custom PR title",
+        }),
+      );
+    });
+
+    it("--force オプションで確認をスキップ", async () => {
+      vol.fromJSON({
+        "/test/.devenv.json": JSON.stringify(validConfig),
+      });
+
+      const pushableFile = {
+        path: "file.txt",
+        type: "added" as const,
+        localContent: "content",
+        templateContent: null,
+      };
+
+      mockGetPushableFiles.mockReturnValue([pushableFile]);
+      mockGetGitHubToken.mockReturnValue("ghp_token");
+      mockPromptPrTitle.mockResolvedValueOnce("feat: add");
+      mockPromptPrBody.mockResolvedValueOnce(undefined);
+      mockCreatePullRequest.mockResolvedValueOnce({
+        url: "https://github.com/owner/repo/pull/1",
+        branch: "update-template-123",
+      });
+
+      await pushCommand.run?.({
+        args: { dir: "/test", dryRun: false, force: true, interactive: true },
+        rawArgs: [],
+        cmd: pushCommand,
+      });
+
+      // ファイル選択プロンプトはスキップ
+      expect(mockPromptSelectFilesWithDiff).not.toHaveBeenCalled();
+      expect(mockPromptPushConfirm).not.toHaveBeenCalled();
+      expect(mockCreatePullRequest).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/create-devenv/src/commands/__tests__/push.test.ts
+++ b/packages/create-devenv/src/commands/__tests__/push.test.ts
@@ -1,6 +1,5 @@
 import { vol } from "memfs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { DiffResult } from "../../modules/schemas";
 
 // fs モジュールをモック
 vi.mock("node:fs", async () => {
@@ -128,11 +127,9 @@ const validConfig = {
   },
 };
 
-const emptyDiff: DiffResult = {
-  added: [],
-  modified: [],
-  deleted: [],
-  unchanged: [],
+const emptyDiff = {
+  files: [],
+  summary: { added: 0, modified: 0, deleted: 0, unchanged: 0 },
 };
 
 describe("pushCommand", () => {
@@ -152,8 +149,8 @@ describe("pushCommand", () => {
 
   describe("meta", () => {
     it("コマンドメタデータが正しい", () => {
-      expect(pushCommand.meta?.name).toBe("push");
-      expect(pushCommand.meta?.description).toBe(
+      expect((pushCommand.meta as { name: string }).name).toBe("push");
+      expect((pushCommand.meta as { description: string }).description).toBe(
         "Push local changes to the template repository as a PR",
       );
     });
@@ -161,19 +158,23 @@ describe("pushCommand", () => {
 
   describe("args", () => {
     it("dir 引数のデフォルト値は '.'", () => {
-      expect(pushCommand.args?.dir?.default).toBe(".");
+      const args = pushCommand.args as { dir: { default: string } };
+      expect(args.dir.default).toBe(".");
     });
 
     it("dryRun 引数のデフォルト値は false", () => {
-      expect(pushCommand.args?.dryRun?.default).toBe(false);
+      const args = pushCommand.args as { dryRun: { default: boolean } };
+      expect(args.dryRun.default).toBe(false);
     });
 
     it("force 引数のデフォルト値は false", () => {
-      expect(pushCommand.args?.force?.default).toBe(false);
+      const args = pushCommand.args as { force: { default: boolean } };
+      expect(args.force.default).toBe(false);
     });
 
     it("interactive 引数のデフォルト値は true", () => {
-      expect(pushCommand.args?.interactive?.default).toBe(true);
+      const args = pushCommand.args as { interactive: { default: boolean } };
+      expect(args.interactive.default).toBe(true);
     });
   });
 
@@ -184,7 +185,7 @@ describe("pushCommand", () => {
       });
 
       await expect(
-        pushCommand.run?.({
+        (pushCommand.run as any)({
           args: { dir: "/test", dryRun: false, force: false, interactive: true },
           rawArgs: [],
           cmd: pushCommand,
@@ -202,7 +203,7 @@ describe("pushCommand", () => {
       });
 
       await expect(
-        pushCommand.run?.({
+        (pushCommand.run as any)({
           args: { dir: "/test", dryRun: false, force: false, interactive: true },
           rawArgs: [],
           cmd: pushCommand,
@@ -220,7 +221,7 @@ describe("pushCommand", () => {
         }),
       });
 
-      await pushCommand.run?.({
+      await (pushCommand.run as any)({
         args: { dir: "/test", dryRun: false, force: false, interactive: true },
         rawArgs: [],
         cmd: pushCommand,
@@ -236,7 +237,7 @@ describe("pushCommand", () => {
 
       mockGetPushableFiles.mockReturnValue([]);
 
-      await pushCommand.run?.({
+      await (pushCommand.run as any)({
         args: { dir: "/test", dryRun: false, force: false, interactive: true },
         rawArgs: [],
         cmd: pushCommand,
@@ -253,13 +254,12 @@ describe("pushCommand", () => {
       mockGetPushableFiles.mockReturnValue([
         {
           path: "file.txt",
-          type: "added",
+          type: "added" as const,
           localContent: "content",
-          templateContent: null,
         },
       ]);
 
-      await pushCommand.run?.({
+      await (pushCommand.run as any)({
         args: { dir: "/test", dryRun: true, force: false, interactive: true },
         rawArgs: [],
         cmd: pushCommand,
@@ -278,15 +278,14 @@ describe("pushCommand", () => {
       mockGetPushableFiles.mockReturnValue([
         {
           path: "file.txt",
-          type: "added",
+          type: "added" as const,
           localContent: "content",
-          templateContent: null,
         },
       ]);
 
       mockPromptSelectFilesWithDiff.mockResolvedValueOnce([]);
 
-      await pushCommand.run?.({
+      await (pushCommand.run as any)({
         args: { dir: "/test", dryRun: false, force: false, interactive: true },
         rawArgs: [],
         cmd: pushCommand,
@@ -304,15 +303,14 @@ describe("pushCommand", () => {
       mockGetPushableFiles.mockReturnValue([
         {
           path: "file.txt",
-          type: "added",
+          type: "added" as const,
           localContent: "content",
-          templateContent: null,
         },
       ]);
 
       mockPromptPushConfirm.mockResolvedValueOnce(false);
 
-      await pushCommand.run?.({
+      await (pushCommand.run as any)({
         args: { dir: "/test", dryRun: false, force: false, interactive: false },
         rawArgs: [],
         cmd: pushCommand,
@@ -331,7 +329,6 @@ describe("pushCommand", () => {
         path: "file.txt",
         type: "added" as const,
         localContent: "content",
-        templateContent: null,
       };
 
       mockGetPushableFiles.mockReturnValue([pushableFile]);
@@ -342,9 +339,10 @@ describe("pushCommand", () => {
       mockCreatePullRequest.mockResolvedValueOnce({
         url: "https://github.com/owner/repo/pull/1",
         branch: "update-template-123",
+        number: 1,
       });
 
-      await pushCommand.run?.({
+      await (pushCommand.run as any)({
         args: { dir: "/test", dryRun: false, force: false, interactive: true },
         rawArgs: [],
         cmd: pushCommand,
@@ -371,7 +369,6 @@ describe("pushCommand", () => {
         path: "file.txt",
         type: "added" as const,
         localContent: "content",
-        templateContent: null,
       };
 
       mockGetPushableFiles.mockReturnValue([pushableFile]);
@@ -383,9 +380,10 @@ describe("pushCommand", () => {
       mockCreatePullRequest.mockResolvedValueOnce({
         url: "https://github.com/owner/repo/pull/1",
         branch: "update-template-123",
+        number: 1,
       });
 
-      await pushCommand.run?.({
+      await (pushCommand.run as any)({
         args: { dir: "/test", dryRun: false, force: false, interactive: true },
         rawArgs: [],
         cmd: pushCommand,
@@ -404,7 +402,6 @@ describe("pushCommand", () => {
         path: "file.txt",
         type: "added" as const,
         localContent: "content",
-        templateContent: null,
       };
 
       mockGetPushableFiles.mockReturnValue([pushableFile]);
@@ -414,9 +411,10 @@ describe("pushCommand", () => {
       mockCreatePullRequest.mockResolvedValueOnce({
         url: "https://github.com/owner/repo/pull/1",
         branch: "update-template-123",
+        number: 1,
       });
 
-      await pushCommand.run?.({
+      await (pushCommand.run as any)({
         args: {
           dir: "/test",
           dryRun: false,
@@ -447,7 +445,6 @@ describe("pushCommand", () => {
         path: "file.txt",
         type: "added" as const,
         localContent: "content",
-        templateContent: null,
       };
 
       mockGetPushableFiles.mockReturnValue([pushableFile]);
@@ -457,9 +454,10 @@ describe("pushCommand", () => {
       mockCreatePullRequest.mockResolvedValueOnce({
         url: "https://github.com/owner/repo/pull/1",
         branch: "update-template-123",
+        number: 1,
       });
 
-      await pushCommand.run?.({
+      await (pushCommand.run as any)({
         args: { dir: "/test", dryRun: false, force: true, interactive: true },
         rawArgs: [],
         cmd: pushCommand,

--- a/packages/create-devenv/src/prompts/__tests__/init.test.ts
+++ b/packages/create-devenv/src/prompts/__tests__/init.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TemplateModule } from "../../modules/schemas";
+
+// @inquirer/prompts をモック
+vi.mock("@inquirer/prompts", () => ({
+  checkbox: vi.fn(),
+  select: vi.fn(),
+}));
+
+// モック後にインポート
+const { promptInit } = await import("../init");
+const { checkbox, select } = await import("@inquirer/prompts");
+const mockCheckbox = vi.mocked(checkbox);
+const mockSelect = vi.mocked(select);
+
+const testModules: TemplateModule[] = [
+  {
+    id: "root",
+    name: "Root Config",
+    description: "Root configuration files",
+    patterns: [".mcp.json", ".mise.toml"],
+  },
+  {
+    id: "devcontainer",
+    name: "Dev Container",
+    description: "Docker dev environment",
+    patterns: [".devcontainer/**"],
+  },
+  {
+    id: "github",
+    name: "GitHub",
+    description: "GitHub Actions and configs",
+    patterns: [".github/**"],
+  },
+];
+
+describe("promptInit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("モジュール選択と上書き戦略を返す", async () => {
+    mockCheckbox.mockResolvedValueOnce(["root", "devcontainer"]);
+    mockSelect.mockResolvedValueOnce("prompt");
+
+    const result = await promptInit(testModules);
+
+    expect(result).toEqual({
+      modules: ["root", "devcontainer"],
+      overwriteStrategy: "prompt",
+    });
+  });
+
+  it("全モジュールを選択可能", async () => {
+    mockCheckbox.mockResolvedValueOnce(["root", "devcontainer", "github"]);
+    mockSelect.mockResolvedValueOnce("overwrite");
+
+    const result = await promptInit(testModules);
+
+    expect(result).toEqual({
+      modules: ["root", "devcontainer", "github"],
+      overwriteStrategy: "overwrite",
+    });
+  });
+
+  it("モジュールを1つも選択しない場合はエラー", async () => {
+    mockCheckbox.mockResolvedValueOnce([]);
+    mockSelect.mockResolvedValueOnce("skip");
+
+    await expect(promptInit(testModules)).rejects.toThrow(
+      "少なくとも1つのモジュールを選択してください",
+    );
+  });
+
+  it("overwrite 戦略を選択", async () => {
+    mockCheckbox.mockResolvedValueOnce(["root"]);
+    mockSelect.mockResolvedValueOnce("overwrite");
+
+    const result = await promptInit(testModules);
+
+    expect(result.overwriteStrategy).toBe("overwrite");
+  });
+
+  it("skip 戦略を選択", async () => {
+    mockCheckbox.mockResolvedValueOnce(["root"]);
+    mockSelect.mockResolvedValueOnce("skip");
+
+    const result = await promptInit(testModules);
+
+    expect(result.overwriteStrategy).toBe("skip");
+  });
+
+  it("checkbox にモジュール一覧が渡される", async () => {
+    mockCheckbox.mockResolvedValueOnce(["root"]);
+    mockSelect.mockResolvedValueOnce("prompt");
+
+    await promptInit(testModules);
+
+    expect(mockCheckbox).toHaveBeenCalledWith({
+      message: "適用するテンプレートを選択してください",
+      choices: [
+        {
+          name: "Root Config - Root configuration files",
+          value: "root",
+          checked: true,
+        },
+        {
+          name: "Dev Container - Docker dev environment",
+          value: "devcontainer",
+          checked: true,
+        },
+        {
+          name: "GitHub - GitHub Actions and configs",
+          value: "github",
+          checked: true,
+        },
+      ],
+    });
+  });
+
+  it("select に上書き戦略の選択肢が渡される", async () => {
+    mockCheckbox.mockResolvedValueOnce(["root"]);
+    mockSelect.mockResolvedValueOnce("prompt");
+
+    await promptInit(testModules);
+
+    expect(mockSelect).toHaveBeenCalledWith({
+      message: "既存ファイルが見つかった場合の処理方法",
+      choices: [
+        { name: "確認しながら進める", value: "prompt" },
+        { name: "すべて上書き", value: "overwrite" },
+        { name: "スキップ (既存ファイルを保持)", value: "skip" },
+      ],
+      default: "prompt",
+    });
+  });
+
+  it("無効な上書き戦略の場合はエラー", async () => {
+    mockCheckbox.mockResolvedValueOnce(["root"]);
+    mockSelect.mockResolvedValueOnce("invalid_strategy");
+
+    await expect(promptInit(testModules)).rejects.toThrow();
+  });
+});

--- a/packages/create-devenv/src/prompts/__tests__/push.test.ts
+++ b/packages/create-devenv/src/prompts/__tests__/push.test.ts
@@ -1,0 +1,431 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DiffResult, FileDiff } from "../../modules/schemas";
+import type { UntrackedFilesByFolder } from "../../utils/untracked";
+
+// console.log をモック
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "clear").mockImplementation(() => {});
+
+// @inquirer/prompts をモック
+vi.mock("@inquirer/prompts", () => ({
+  checkbox: vi.fn(),
+  confirm: vi.fn(),
+  input: vi.fn(),
+  password: vi.fn(),
+  Separator: class Separator {
+    separator = true;
+    constructor(public line?: string) {}
+  },
+}));
+
+// diff-viewer をモック
+vi.mock("../../utils/diff-viewer", () => ({
+  getFileLabel: vi.fn((file: FileDiff) => `${file.type}: ${file.path}`),
+  showDiffSummaryBox: vi.fn(),
+  showFileDiffBox: vi.fn(),
+}));
+
+// diff をモック
+vi.mock("../../utils/diff", () => ({
+  formatDiff: vi.fn(() => "mocked diff output"),
+}));
+
+// モック後にインポート
+const {
+  promptPushConfirm,
+  promptPrTitle,
+  promptPrBody,
+  promptGitHubToken,
+  promptSelectFilesWithDiff,
+  promptAddUntrackedFiles,
+} = await import("../push");
+const { checkbox, confirm, input, password } = await import("@inquirer/prompts");
+const mockCheckbox = vi.mocked(checkbox);
+const mockConfirm = vi.mocked(confirm);
+const mockInput = vi.mocked(input);
+const mockPassword = vi.mocked(password);
+
+describe("promptPushConfirm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("true を返す場合", async () => {
+    mockConfirm.mockResolvedValueOnce(true);
+
+    const diff: DiffResult = {
+      added: [],
+      modified: [],
+      deleted: [],
+      unchanged: [],
+    };
+
+    const result = await promptPushConfirm(diff);
+
+    expect(result).toBe(true);
+    expect(mockConfirm).toHaveBeenCalledWith({
+      message: "これらの変更をテンプレートリポジトリに PR として送信しますか？",
+      default: false,
+    });
+  });
+
+  it("false を返す場合", async () => {
+    mockConfirm.mockResolvedValueOnce(false);
+
+    const diff: DiffResult = {
+      added: [],
+      modified: [],
+      deleted: [],
+      unchanged: [],
+    };
+
+    const result = await promptPushConfirm(diff);
+
+    expect(result).toBe(false);
+  });
+});
+
+describe("promptPrTitle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("入力されたタイトルを返す", async () => {
+    mockInput.mockResolvedValueOnce("feat: add new feature");
+
+    const result = await promptPrTitle();
+
+    expect(result).toBe("feat: add new feature");
+  });
+
+  it("デフォルトタイトルを使用", async () => {
+    mockInput.mockResolvedValueOnce("custom default");
+
+    await promptPrTitle("custom default");
+
+    expect(mockInput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        default: "custom default",
+      }),
+    );
+  });
+
+  it("デフォルトタイトルが指定されない場合", async () => {
+    mockInput.mockResolvedValueOnce("some title");
+
+    await promptPrTitle();
+
+    expect(mockInput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        default: "feat: テンプレート設定を更新",
+      }),
+    );
+  });
+
+  it("バリデーション: 空のタイトルは拒否", async () => {
+    mockInput.mockImplementationOnce(async (options) => {
+      const validate = options.validate as (value: string) => boolean | string;
+      const emptyResult = validate("");
+      const whitespaceResult = validate("   ");
+      expect(emptyResult).toBe("タイトルは必須です");
+      expect(whitespaceResult).toBe("タイトルは必須です");
+      return "valid title";
+    });
+
+    await promptPrTitle();
+  });
+
+  it("バリデーション: 有効なタイトルは許可", async () => {
+    mockInput.mockImplementationOnce(async (options) => {
+      const validate = options.validate as (value: string) => boolean | string;
+      const result = validate("Valid Title");
+      expect(result).toBe(true);
+      return "Valid Title";
+    });
+
+    await promptPrTitle();
+  });
+});
+
+describe("promptPrBody", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("説明を追加しない場合は undefined を返す", async () => {
+    mockConfirm.mockResolvedValueOnce(false);
+
+    const result = await promptPrBody();
+
+    expect(result).toBeUndefined();
+    expect(mockInput).not.toHaveBeenCalled();
+  });
+
+  it("説明を追加する場合は入力内容を返す", async () => {
+    mockConfirm.mockResolvedValueOnce(true);
+    mockInput.mockResolvedValueOnce("This is the PR description");
+
+    const result = await promptPrBody();
+
+    expect(result).toBe("This is the PR description");
+    expect(mockInput).toHaveBeenCalledWith({
+      message: "PR の説明を入力してください",
+    });
+  });
+});
+
+describe("promptGitHubToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("入力されたトークンを返す", async () => {
+    mockPassword.mockResolvedValueOnce("ghp_xxxxxxxxxxxx");
+
+    const result = await promptGitHubToken();
+
+    expect(result).toBe("ghp_xxxxxxxxxxxx");
+  });
+
+  it("バリデーション: 空のトークンは拒否", async () => {
+    mockPassword.mockImplementationOnce(async (options) => {
+      const validate = options.validate as (value: string) => boolean | string;
+      const emptyResult = validate("");
+      const whitespaceResult = validate("   ");
+      expect(emptyResult).toBe("トークンは必須です");
+      expect(whitespaceResult).toBe("トークンは必須です");
+      return "ghp_valid";
+    });
+
+    await promptGitHubToken();
+  });
+
+  it("バリデーション: ghp_ プレフィックスは許可", async () => {
+    mockPassword.mockImplementationOnce(async (options) => {
+      const validate = options.validate as (value: string) => boolean | string;
+      const result = validate("ghp_abcdefghij");
+      expect(result).toBe(true);
+      return "ghp_abcdefghij";
+    });
+
+    await promptGitHubToken();
+  });
+
+  it("バリデーション: gho_ プレフィックスは許可", async () => {
+    mockPassword.mockImplementationOnce(async (options) => {
+      const validate = options.validate as (value: string) => boolean | string;
+      const result = validate("gho_abcdefghij");
+      expect(result).toBe(true);
+      return "gho_abcdefghij";
+    });
+
+    await promptGitHubToken();
+  });
+
+  it("バリデーション: github_pat_ プレフィックスは許可", async () => {
+    mockPassword.mockImplementationOnce(async (options) => {
+      const validate = options.validate as (value: string) => boolean | string;
+      const result = validate("github_pat_abcdefghij");
+      expect(result).toBe(true);
+      return "github_pat_abcdefghij";
+    });
+
+    await promptGitHubToken();
+  });
+
+  it("バリデーション: 無効な形式は拒否", async () => {
+    mockPassword.mockImplementationOnce(async (options) => {
+      const validate = options.validate as (value: string) => boolean | string;
+      const result = validate("invalid_token");
+      expect(result).toBe("有効な GitHub トークン形式ではありません");
+      return "ghp_valid";
+    });
+
+    await promptGitHubToken();
+  });
+});
+
+describe("promptSelectFilesWithDiff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("空の配列の場合は空の配列を返す", async () => {
+    const result = await promptSelectFilesWithDiff([]);
+
+    expect(result).toEqual([]);
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(mockCheckbox).not.toHaveBeenCalled();
+  });
+
+  it("詳細確認しない場合はファイル選択のみ", async () => {
+    const files: FileDiff[] = [
+      {
+        path: "file1.txt",
+        type: "added",
+        localContent: "content1",
+        templateContent: null,
+      },
+      {
+        path: "file2.txt",
+        type: "modified",
+        localContent: "new content",
+        templateContent: "old content",
+      },
+    ];
+
+    mockConfirm.mockResolvedValueOnce(false); // 詳細確認しない
+    mockCheckbox.mockResolvedValueOnce(files);
+
+    const result = await promptSelectFilesWithDiff(files);
+
+    expect(result).toEqual(files);
+    expect(mockConfirm).toHaveBeenCalledWith({
+      message: "詳細な diff を確認しますか？",
+      default: false,
+    });
+  });
+
+  it("ファイルを選択しない場合は空の配列", async () => {
+    const files: FileDiff[] = [
+      {
+        path: "file1.txt",
+        type: "added",
+        localContent: "content1",
+        templateContent: null,
+      },
+    ];
+
+    mockConfirm.mockResolvedValueOnce(false);
+    mockCheckbox.mockResolvedValueOnce([]);
+
+    const result = await promptSelectFilesWithDiff(files);
+
+    expect(result).toEqual([]);
+  });
+
+  it("一部のファイルのみ選択", async () => {
+    const files: FileDiff[] = [
+      {
+        path: "file1.txt",
+        type: "added",
+        localContent: "content1",
+        templateContent: null,
+      },
+      {
+        path: "file2.txt",
+        type: "modified",
+        localContent: "new",
+        templateContent: "old",
+      },
+    ];
+
+    mockConfirm.mockResolvedValueOnce(false);
+    mockCheckbox.mockResolvedValueOnce([files[0]]);
+
+    const result = await promptSelectFilesWithDiff(files);
+
+    expect(result).toEqual([files[0]]);
+  });
+});
+
+describe("promptAddUntrackedFiles", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("空の配列の場合は空の配列を返す", async () => {
+    const result = await promptAddUntrackedFiles([]);
+
+    expect(result).toEqual([]);
+    expect(mockCheckbox).not.toHaveBeenCalled();
+  });
+
+  it("フォルダを選択しない場合は空の配列", async () => {
+    const untrackedByFolder: UntrackedFilesByFolder[] = [
+      {
+        folder: ".github",
+        files: [{ path: ".github/new-file.yml", moduleId: ".github" }],
+      },
+    ];
+
+    mockCheckbox.mockResolvedValueOnce([]); // フォルダ未選択
+
+    const result = await promptAddUntrackedFiles(untrackedByFolder);
+
+    expect(result).toEqual([]);
+  });
+
+  it("ファイルを選択しない場合は空の配列", async () => {
+    const untrackedByFolder: UntrackedFilesByFolder[] = [
+      {
+        folder: ".github",
+        files: [{ path: ".github/new-file.yml", moduleId: ".github" }],
+      },
+    ];
+
+    mockCheckbox
+      .mockResolvedValueOnce([".github"]) // フォルダ選択
+      .mockResolvedValueOnce([]); // ファイル未選択
+
+    const result = await promptAddUntrackedFiles(untrackedByFolder);
+
+    expect(result).toEqual([]);
+  });
+
+  it("ファイルを選択した場合は moduleId ごとにグループ化", async () => {
+    const untrackedByFolder: UntrackedFilesByFolder[] = [
+      {
+        folder: ".github",
+        files: [
+          { path: ".github/file1.yml", moduleId: ".github" },
+          { path: ".github/file2.yml", moduleId: ".github" },
+        ],
+      },
+    ];
+
+    const selectedFiles = untrackedByFolder[0].files;
+
+    mockCheckbox.mockResolvedValueOnce([".github"]).mockResolvedValueOnce(selectedFiles);
+
+    const result = await promptAddUntrackedFiles(untrackedByFolder);
+
+    expect(result).toEqual([
+      {
+        moduleId: ".github",
+        files: [".github/file1.yml", ".github/file2.yml"],
+      },
+    ]);
+  });
+
+  it("複数フォルダからファイルを選択", async () => {
+    const untrackedByFolder: UntrackedFilesByFolder[] = [
+      {
+        folder: ".github",
+        files: [{ path: ".github/file1.yml", moduleId: ".github" }],
+      },
+      {
+        folder: ".devcontainer",
+        files: [{ path: ".devcontainer/file.json", moduleId: ".devcontainer" }],
+      },
+    ];
+
+    const allFiles = [untrackedByFolder[0].files[0], untrackedByFolder[1].files[0]];
+
+    mockCheckbox
+      .mockResolvedValueOnce([".github", ".devcontainer"])
+      .mockResolvedValueOnce(allFiles);
+
+    const result = await promptAddUntrackedFiles(untrackedByFolder);
+
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({
+      moduleId: ".github",
+      files: [".github/file1.yml"],
+    });
+    expect(result).toContainEqual({
+      moduleId: ".devcontainer",
+      files: [".devcontainer/file.json"],
+    });
+  });
+});

--- a/packages/create-devenv/src/prompts/__tests__/push.test.ts
+++ b/packages/create-devenv/src/prompts/__tests__/push.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { DiffResult, FileDiff } from "../../modules/schemas";
+import type { FileDiff } from "../../modules/schemas";
 import type { UntrackedFilesByFolder } from "../../utils/untracked";
 
 // console.log をモック
@@ -53,11 +53,9 @@ describe("promptPushConfirm", () => {
   it("true を返す場合", async () => {
     mockConfirm.mockResolvedValueOnce(true);
 
-    const diff: DiffResult = {
-      added: [],
-      modified: [],
-      deleted: [],
-      unchanged: [],
+    const diff = {
+      files: [],
+      summary: { added: 0, modified: 0, deleted: 0, unchanged: 0 },
     };
 
     const result = await promptPushConfirm(diff);
@@ -72,11 +70,9 @@ describe("promptPushConfirm", () => {
   it("false を返す場合", async () => {
     mockConfirm.mockResolvedValueOnce(false);
 
-    const diff: DiffResult = {
-      added: [],
-      modified: [],
-      deleted: [],
-      unchanged: [],
+    const diff = {
+      files: [],
+      summary: { added: 0, modified: 0, deleted: 0, unchanged: 0 },
     };
 
     const result = await promptPushConfirm(diff);
@@ -264,7 +260,6 @@ describe("promptSelectFilesWithDiff", () => {
         path: "file1.txt",
         type: "added",
         localContent: "content1",
-        templateContent: null,
       },
       {
         path: "file2.txt",
@@ -292,7 +287,6 @@ describe("promptSelectFilesWithDiff", () => {
         path: "file1.txt",
         type: "added",
         localContent: "content1",
-        templateContent: null,
       },
     ];
 
@@ -310,7 +304,6 @@ describe("promptSelectFilesWithDiff", () => {
         path: "file1.txt",
         type: "added",
         localContent: "content1",
-        templateContent: null,
       },
       {
         path: "file2.txt",
@@ -345,7 +338,7 @@ describe("promptAddUntrackedFiles", () => {
     const untrackedByFolder: UntrackedFilesByFolder[] = [
       {
         folder: ".github",
-        files: [{ path: ".github/new-file.yml", moduleId: ".github" }],
+        files: [{ path: ".github/new-file.yml", folder: ".github", moduleId: ".github" }],
       },
     ];
 
@@ -360,7 +353,7 @@ describe("promptAddUntrackedFiles", () => {
     const untrackedByFolder: UntrackedFilesByFolder[] = [
       {
         folder: ".github",
-        files: [{ path: ".github/new-file.yml", moduleId: ".github" }],
+        files: [{ path: ".github/new-file.yml", folder: ".github", moduleId: ".github" }],
       },
     ];
 
@@ -378,8 +371,8 @@ describe("promptAddUntrackedFiles", () => {
       {
         folder: ".github",
         files: [
-          { path: ".github/file1.yml", moduleId: ".github" },
-          { path: ".github/file2.yml", moduleId: ".github" },
+          { path: ".github/file1.yml", folder: ".github", moduleId: ".github" },
+          { path: ".github/file2.yml", folder: ".github", moduleId: ".github" },
         ],
       },
     ];
@@ -402,11 +395,13 @@ describe("promptAddUntrackedFiles", () => {
     const untrackedByFolder: UntrackedFilesByFolder[] = [
       {
         folder: ".github",
-        files: [{ path: ".github/file1.yml", moduleId: ".github" }],
+        files: [{ path: ".github/file1.yml", folder: ".github", moduleId: ".github" }],
       },
       {
         folder: ".devcontainer",
-        files: [{ path: ".devcontainer/file.json", moduleId: ".devcontainer" }],
+        files: [
+          { path: ".devcontainer/file.json", folder: ".devcontainer", moduleId: ".devcontainer" },
+        ],
       },
     ];
 

--- a/packages/create-devenv/src/utils/__tests__/ui.test.ts
+++ b/packages/create-devenv/src/utils/__tests__/ui.test.ts
@@ -1,0 +1,359 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FileResult, Summary } from "../ui";
+import {
+  box,
+  calculateSummary,
+  diffFile,
+  diffHeader,
+  formatPath,
+  log,
+  logFileResult,
+  showHeader,
+  showNextSteps,
+  showSummary,
+  step,
+  substep,
+} from "../ui";
+
+// console.log をモック
+const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+describe("ui utilities", () => {
+  beforeEach(() => {
+    mockConsoleLog.mockClear();
+  });
+
+  describe("calculateSummary", () => {
+    it("空の結果配列の場合はすべて0", () => {
+      const results: FileResult[] = [];
+      const summary = calculateSummary(results);
+
+      expect(summary).toEqual<Summary>({
+        added: 0,
+        updated: 0,
+        skipped: 0,
+      });
+    });
+
+    it("copied アクションは added としてカウント", () => {
+      const results: FileResult[] = [
+        { action: "copied", path: "file1.txt" },
+        { action: "copied", path: "file2.txt" },
+      ];
+      const summary = calculateSummary(results);
+
+      expect(summary).toEqual<Summary>({
+        added: 2,
+        updated: 0,
+        skipped: 0,
+      });
+    });
+
+    it("created アクションは added としてカウント", () => {
+      const results: FileResult[] = [
+        { action: "created", path: "file1.txt" },
+        { action: "created", path: "file2.txt" },
+      ];
+      const summary = calculateSummary(results);
+
+      expect(summary).toEqual<Summary>({
+        added: 2,
+        updated: 0,
+        skipped: 0,
+      });
+    });
+
+    it("overwritten アクションは updated としてカウント", () => {
+      const results: FileResult[] = [
+        { action: "overwritten", path: "file1.txt" },
+        { action: "overwritten", path: "file2.txt" },
+      ];
+      const summary = calculateSummary(results);
+
+      expect(summary).toEqual<Summary>({
+        added: 0,
+        updated: 2,
+        skipped: 0,
+      });
+    });
+
+    it("skipped アクションは skipped としてカウント", () => {
+      const results: FileResult[] = [
+        { action: "skipped", path: "file1.txt" },
+        { action: "skipped", path: "file2.txt" },
+      ];
+      const summary = calculateSummary(results);
+
+      expect(summary).toEqual<Summary>({
+        added: 0,
+        updated: 0,
+        skipped: 2,
+      });
+    });
+
+    it("混合アクションを正しくカウント", () => {
+      const results: FileResult[] = [
+        { action: "copied", path: "new1.txt" },
+        { action: "created", path: "new2.txt" },
+        { action: "overwritten", path: "updated.txt" },
+        { action: "skipped", path: "skip1.txt" },
+        { action: "skipped", path: "skip2.txt" },
+      ];
+      const summary = calculateSummary(results);
+
+      expect(summary).toEqual<Summary>({
+        added: 2,
+        updated: 1,
+        skipped: 2,
+      });
+    });
+  });
+
+  describe("formatPath", () => {
+    it("先頭に ./ がない場合は追加する", () => {
+      expect(formatPath("file.txt")).toBe("./file.txt");
+      expect(formatPath("dir/file.txt")).toBe("./dir/file.txt");
+    });
+
+    it("先頭に ./ がある場合はそのまま", () => {
+      expect(formatPath("./file.txt")).toBe("./file.txt");
+      expect(formatPath("./dir/file.txt")).toBe("./dir/file.txt");
+    });
+  });
+
+  describe("log", () => {
+    it("success はメッセージを出力", () => {
+      log.success("Success message");
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("Success message");
+    });
+
+    it("error はメッセージを出力", () => {
+      log.error("Error message");
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("Error message");
+    });
+
+    it("warn はメッセージを出力", () => {
+      log.warn("Warning message");
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("Warning message");
+    });
+
+    it("info はメッセージを出力", () => {
+      log.info("Info message");
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("Info message");
+    });
+
+    it("dim はメッセージを出力", () => {
+      log.dim("Dim message");
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("Dim message");
+    });
+
+    it("newline は空行を出力", () => {
+      log.newline();
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog).toHaveBeenCalledWith();
+    });
+  });
+
+  describe("showHeader", () => {
+    it("タイトルのみの場合", () => {
+      showHeader("Test Title");
+      expect(mockConsoleLog).toHaveBeenCalledTimes(3); // 空行、タイトル、区切り線
+      expect(mockConsoleLog.mock.calls[1][0]).toContain("Test Title");
+    });
+
+    it("タイトルとバージョンの場合", () => {
+      showHeader("Test Title", "1.0.0");
+      expect(mockConsoleLog).toHaveBeenCalledTimes(3);
+      expect(mockConsoleLog.mock.calls[1][0]).toContain("Test Title");
+      expect(mockConsoleLog.mock.calls[1][0]).toContain("1.0.0");
+    });
+  });
+
+  describe("step", () => {
+    it("ステップ番号とメッセージを表示", () => {
+      step({ current: 1, total: 3 }, "Fetching template...");
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("[1/3]");
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("Fetching template...");
+    });
+  });
+
+  describe("substep", () => {
+    it("サブステップを表示", () => {
+      substep("Sub task");
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("Sub task");
+    });
+
+    it("最後のサブステップは別のプレフィックス", () => {
+      substep("Last sub task", true);
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("Last sub task");
+    });
+  });
+
+  describe("logFileResult", () => {
+    it("copied アクションを表示", () => {
+      logFileResult({ action: "copied", path: "file.txt" });
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("file.txt");
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("added");
+    });
+
+    it("created アクションを表示", () => {
+      logFileResult({ action: "created", path: "file.txt" });
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("file.txt");
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("added");
+    });
+
+    it("overwritten アクションを表示", () => {
+      logFileResult({ action: "overwritten", path: "file.txt" });
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("file.txt");
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("updated");
+    });
+
+    it("skipped アクションを表示", () => {
+      logFileResult({ action: "skipped", path: "file.txt" });
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("file.txt");
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("skipped");
+    });
+  });
+
+  describe("showSummary", () => {
+    it("added のみの場合", () => {
+      showSummary({ added: 3, updated: 0, skipped: 0 });
+      expect(mockConsoleLog).toHaveBeenCalled();
+      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join(" ");
+      expect(output).toContain("3 added");
+      expect(output).toContain("Done!");
+    });
+
+    it("updated のみの場合", () => {
+      showSummary({ added: 0, updated: 2, skipped: 0 });
+      expect(mockConsoleLog).toHaveBeenCalled();
+      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join(" ");
+      expect(output).toContain("2 updated");
+    });
+
+    it("skipped のみの場合", () => {
+      showSummary({ added: 0, updated: 0, skipped: 5 });
+      expect(mockConsoleLog).toHaveBeenCalled();
+      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join(" ");
+      expect(output).toContain("5 skipped");
+    });
+
+    it("すべて0の場合は何も表示しない", () => {
+      showSummary({ added: 0, updated: 0, skipped: 0 });
+      expect(mockConsoleLog).not.toHaveBeenCalled();
+    });
+
+    it("混合の場合", () => {
+      showSummary({ added: 1, updated: 2, skipped: 3 });
+      expect(mockConsoleLog).toHaveBeenCalled();
+      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join(" ");
+      expect(output).toContain("1 added");
+      expect(output).toContain("2 updated");
+      expect(output).toContain("3 skipped");
+    });
+  });
+
+  describe("showNextSteps", () => {
+    it("空の配列の場合は何も表示しない", () => {
+      showNextSteps([]);
+      expect(mockConsoleLog).not.toHaveBeenCalled();
+    });
+
+    it("コマンドありのステップを表示", () => {
+      showNextSteps([{ command: "npm run test", description: "Run tests" }]);
+      expect(mockConsoleLog).toHaveBeenCalled();
+      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join(" ");
+      expect(output).toContain("npm run test");
+      expect(output).toContain("Run tests");
+    });
+
+    it("コマンドなしのステップを表示", () => {
+      showNextSteps([{ description: "Just a description" }]);
+      expect(mockConsoleLog).toHaveBeenCalled();
+      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join(" ");
+      expect(output).toContain("Just a description");
+    });
+
+    it("複数のステップを表示", () => {
+      showNextSteps([
+        { command: "cmd1", description: "desc1" },
+        { command: "cmd2", description: "desc2" },
+      ]);
+      expect(mockConsoleLog).toHaveBeenCalled();
+      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join(" ");
+      expect(output).toContain("cmd1");
+      expect(output).toContain("cmd2");
+    });
+  });
+
+  describe("box", () => {
+    it("success タイプのボックスを表示", () => {
+      box("Success!", "success");
+      expect(mockConsoleLog).toHaveBeenCalled();
+      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join(" ");
+      expect(output).toContain("Success!");
+    });
+
+    it("info タイプのボックスを表示", () => {
+      box("Info message", "info");
+      expect(mockConsoleLog).toHaveBeenCalled();
+      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join(" ");
+      expect(output).toContain("Info message");
+    });
+
+    it("warning タイプのボックスを表示", () => {
+      box("Warning!", "warning");
+      expect(mockConsoleLog).toHaveBeenCalled();
+      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join(" ");
+      expect(output).toContain("Warning!");
+    });
+
+    it("デフォルトは info タイプ", () => {
+      box("Default type");
+      expect(mockConsoleLog).toHaveBeenCalled();
+      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join(" ");
+      expect(output).toContain("Default type");
+    });
+  });
+
+  describe("diffHeader", () => {
+    it("ヘッダーを表示", () => {
+      diffHeader("Changes:");
+      expect(mockConsoleLog).toHaveBeenCalled();
+      const output = mockConsoleLog.mock.calls.map((c) => c[0]).join(" ");
+      expect(output).toContain("Changes:");
+    });
+  });
+
+  describe("diffFile", () => {
+    it("added タイプを表示", () => {
+      diffFile("new-file.txt", "added");
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("new-file.txt");
+    });
+
+    it("modified タイプを表示", () => {
+      diffFile("changed-file.txt", "modified");
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("changed-file.txt");
+    });
+
+    it("deleted タイプを表示", () => {
+      diffFile("removed-file.txt", "deleted");
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog.mock.calls[0][0]).toContain("removed-file.txt");
+    });
+  });
+});


### PR DESCRIPTION
…nd UI

- Add tests for utils/ui.ts (calculateSummary, formatPath, log, etc.)
- Add tests for prompts/init.ts (promptInit with module selection)
- Add tests for prompts/push.ts (PR creation prompts, token validation)
- Add tests for commands/init.ts (init command flow)
- Add tests for commands/diff.ts (diff command flow)
- Add tests for commands/push.ts (push command flow)

Total: 319 tests passing (expanded from 247)