### PR TITLE
Set up development environment with create-devenv

### DIFF
--- a/.changeset/loud-wombats-remain.md
+++ b/.changeset/loud-wombats-remain.md
@@ -1,0 +1,9 @@
+---
+"@tktco/create-devenv": patch
+---
+
+fix(create-devenv): fix stdin conflict between @inquirer/prompts and interactive diff viewer
+
+- Clear existing keypress listeners before setting up interactive viewer to prevent conflicts with @inquirer/prompts
+- Call stdin.resume() to ensure stdin is in correct state after @inquirer/prompts usage
+- Properly restore stdin state in cleanup for subsequent prompts

--- a/packages/create-devenv/src/prompts/__tests__/push.test.ts
+++ b/packages/create-devenv/src/prompts/__tests__/push.test.ts
@@ -508,17 +508,19 @@ describe("interactiveDiffViewer (via promptSelectFilesWithDiff)", () => {
 
     // 全ファイルが showFileDiffBox で表示される
     expect(mockShowFileDiffBox).toHaveBeenCalledTimes(2);
-    expect(mockShowFileDiffBox).toHaveBeenNthCalledWith(1, files[0], 0, 2, { showLineNumbers: true });
-    expect(mockShowFileDiffBox).toHaveBeenNthCalledWith(2, files[1], 1, 2, { showLineNumbers: true });
+    expect(mockShowFileDiffBox).toHaveBeenNthCalledWith(1, files[0], 0, 2, {
+      showLineNumbers: true,
+    });
+    expect(mockShowFileDiffBox).toHaveBeenNthCalledWith(2, files[1], 1, 2, {
+      showLineNumbers: true,
+    });
 
     // readline.emitKeypressEvents は呼ばれない
     expect(mockEmitKeypressEvents).not.toHaveBeenCalled();
   });
 
   it("TTY の場合は stdin のリスナーをリセットしてセットアップ", async () => {
-    const files: FileDiff[] = [
-      { path: "file1.txt", type: "added", localContent: "content1" },
-    ];
+    const files: FileDiff[] = [{ path: "file1.txt", type: "added", localContent: "content1" }];
 
     mockConfirm.mockResolvedValueOnce(true); // 詳細確認する
     mockCheckbox.mockResolvedValueOnce(files);
@@ -604,9 +606,7 @@ describe("interactiveDiffViewer (via promptSelectFilesWithDiff)", () => {
   });
 
   it("Enter キーで終了", async () => {
-    const files: FileDiff[] = [
-      { path: "file1.txt", type: "added", localContent: "content1" },
-    ];
+    const files: FileDiff[] = [{ path: "file1.txt", type: "added", localContent: "content1" }];
 
     mockConfirm.mockResolvedValueOnce(true);
     mockCheckbox.mockResolvedValueOnce(files);
@@ -647,9 +647,7 @@ describe("interactiveDiffViewer (via promptSelectFilesWithDiff)", () => {
   });
 
   it("最後のファイルで n を押しても移動しない", async () => {
-    const files: FileDiff[] = [
-      { path: "file1.txt", type: "added", localContent: "content1" },
-    ];
+    const files: FileDiff[] = [{ path: "file1.txt", type: "added", localContent: "content1" }];
 
     mockConfirm.mockResolvedValueOnce(true);
     mockCheckbox.mockResolvedValueOnce(files);
@@ -668,9 +666,7 @@ describe("interactiveDiffViewer (via promptSelectFilesWithDiff)", () => {
   });
 
   it("cleanup 後は次の @inquirer/prompts が使えるよう stdin が復元される", async () => {
-    const files: FileDiff[] = [
-      { path: "file1.txt", type: "added", localContent: "content1" },
-    ];
+    const files: FileDiff[] = [{ path: "file1.txt", type: "added", localContent: "content1" }];
 
     mockConfirm.mockResolvedValueOnce(true);
     mockCheckbox.mockResolvedValueOnce(files);

--- a/packages/create-devenv/src/prompts/__tests__/push.test.ts
+++ b/packages/create-devenv/src/prompts/__tests__/push.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import type * as readline from "node:readline";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FileDiff } from "../../modules/schemas";
 import type { UntrackedFilesByFolder } from "../../utils/untracked";
 
@@ -30,6 +31,11 @@ vi.mock("../../utils/diff", () => ({
   formatDiff: vi.fn(() => "mocked diff output"),
 }));
 
+// readline をモック
+vi.mock("node:readline", () => ({
+  emitKeypressEvents: vi.fn(),
+}));
+
 // モック後にインポート
 const {
   promptPushConfirm,
@@ -40,10 +46,14 @@ const {
   promptAddUntrackedFiles,
 } = await import("../push");
 const { checkbox, confirm, input, password } = await import("@inquirer/prompts");
+const { showFileDiffBox } = await import("../../utils/diff-viewer");
+const readlineMock = await import("node:readline");
 const mockCheckbox = vi.mocked(checkbox);
 const mockConfirm = vi.mocked(confirm);
 const mockInput = vi.mocked(input);
 const mockPassword = vi.mocked(password);
+const mockShowFileDiffBox = vi.mocked(showFileDiffBox);
+const mockEmitKeypressEvents = vi.mocked(readlineMock.emitKeypressEvents);
 
 describe("promptPushConfirm", () => {
   beforeEach(() => {
@@ -422,5 +432,259 @@ describe("promptAddUntrackedFiles", () => {
       moduleId: ".devcontainer",
       files: [".devcontainer/file.json"],
     });
+  });
+});
+
+describe("interactiveDiffViewer (via promptSelectFilesWithDiff)", () => {
+  // stdin をモックするためのヘルパー
+  type KeypressHandler = (str: string, key: readline.Key) => void;
+  let keypressHandlers: KeypressHandler[] = [];
+  let originalStdin: typeof process.stdin;
+  let mockStdin: {
+    isTTY: boolean;
+    removeAllListeners: ReturnType<typeof vi.fn>;
+    removeListener: ReturnType<typeof vi.fn>;
+    setRawMode: ReturnType<typeof vi.fn>;
+    resume: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    keypressHandlers = [];
+
+    // stdin のモックを作成
+    mockStdin = {
+      isTTY: true,
+      removeAllListeners: vi.fn().mockReturnThis(),
+      removeListener: vi.fn().mockReturnThis(),
+      setRawMode: vi.fn().mockReturnThis(),
+      resume: vi.fn().mockReturnThis(),
+      on: vi.fn((event: string, handler: KeypressHandler) => {
+        if (event === "keypress") {
+          keypressHandlers.push(handler);
+        }
+        return mockStdin;
+      }),
+    };
+
+    // process.stdin を差し替え
+    originalStdin = process.stdin;
+    Object.defineProperty(process, "stdin", {
+      value: mockStdin,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    // process.stdin を復元
+    Object.defineProperty(process, "stdin", {
+      value: originalStdin,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  // キー入力をシミュレート
+  const simulateKeypress = (key: Partial<readline.Key>) => {
+    for (const handler of keypressHandlers) {
+      handler("", key as readline.Key);
+    }
+  };
+
+  it("TTY でない場合は全ファイルを順次表示して終了", async () => {
+    mockStdin.isTTY = false;
+
+    const files: FileDiff[] = [
+      { path: "file1.txt", type: "added", localContent: "content1" },
+      { path: "file2.txt", type: "modified", localContent: "new", templateContent: "old" },
+    ];
+
+    mockConfirm.mockResolvedValueOnce(true); // 詳細確認する
+    mockCheckbox.mockResolvedValueOnce(files);
+
+    await promptSelectFilesWithDiff(files);
+
+    // 全ファイルが showFileDiffBox で表示される
+    expect(mockShowFileDiffBox).toHaveBeenCalledTimes(2);
+    expect(mockShowFileDiffBox).toHaveBeenNthCalledWith(1, files[0], 0, 2, { showLineNumbers: true });
+    expect(mockShowFileDiffBox).toHaveBeenNthCalledWith(2, files[1], 1, 2, { showLineNumbers: true });
+
+    // readline.emitKeypressEvents は呼ばれない
+    expect(mockEmitKeypressEvents).not.toHaveBeenCalled();
+  });
+
+  it("TTY の場合は stdin のリスナーをリセットしてセットアップ", async () => {
+    const files: FileDiff[] = [
+      { path: "file1.txt", type: "added", localContent: "content1" },
+    ];
+
+    mockConfirm.mockResolvedValueOnce(true); // 詳細確認する
+    mockCheckbox.mockResolvedValueOnce(files);
+
+    // 非同期で q キーを押してビューワーを終了
+    setTimeout(() => {
+      simulateKeypress({ name: "q" });
+    }, 10);
+
+    await promptSelectFilesWithDiff(files);
+
+    // 既存の keypress リスナーが削除される
+    expect(mockStdin.removeAllListeners).toHaveBeenCalledWith("keypress");
+
+    // readline.emitKeypressEvents が呼ばれる
+    expect(mockEmitKeypressEvents).toHaveBeenCalledWith(mockStdin);
+
+    // stdin がセットアップされる
+    expect(mockStdin.setRawMode).toHaveBeenCalledWith(true);
+    expect(mockStdin.resume).toHaveBeenCalled();
+    expect(mockStdin.on).toHaveBeenCalledWith("keypress", expect.any(Function));
+  });
+
+  it("n キーで次のファイルに移動", async () => {
+    const files: FileDiff[] = [
+      { path: "file1.txt", type: "added", localContent: "content1" },
+      { path: "file2.txt", type: "modified", localContent: "new", templateContent: "old" },
+    ];
+
+    mockConfirm.mockResolvedValueOnce(true);
+    mockCheckbox.mockResolvedValueOnce(files);
+
+    setTimeout(() => {
+      // 最初のファイルが表示された後、n を押して次へ
+      simulateKeypress({ name: "n" });
+      // その後 q で終了
+      setTimeout(() => {
+        simulateKeypress({ name: "q" });
+      }, 10);
+    }, 10);
+
+    await promptSelectFilesWithDiff(files);
+
+    // 最初のファイル + n で次のファイル = 2回表示
+    expect(mockShowFileDiffBox).toHaveBeenCalledWith(
+      files[0],
+      0,
+      2,
+      expect.objectContaining({ showLineNumbers: true }),
+    );
+    expect(mockShowFileDiffBox).toHaveBeenCalledWith(
+      files[1],
+      1,
+      2,
+      expect.objectContaining({ showLineNumbers: true }),
+    );
+  });
+
+  it("p キーで前のファイルに移動", async () => {
+    const files: FileDiff[] = [
+      { path: "file1.txt", type: "added", localContent: "content1" },
+      { path: "file2.txt", type: "modified", localContent: "new", templateContent: "old" },
+    ];
+
+    mockConfirm.mockResolvedValueOnce(true);
+    mockCheckbox.mockResolvedValueOnce(files);
+
+    setTimeout(() => {
+      simulateKeypress({ name: "n" }); // 次へ
+      setTimeout(() => {
+        simulateKeypress({ name: "p" }); // 前へ
+        setTimeout(() => {
+          simulateKeypress({ name: "q" }); // 終了
+        }, 10);
+      }, 10);
+    }, 10);
+
+    await promptSelectFilesWithDiff(files);
+
+    // file1 → file2 → file1 の順で表示される
+    const calls = mockShowFileDiffBox.mock.calls;
+    expect(calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("Enter キーで終了", async () => {
+    const files: FileDiff[] = [
+      { path: "file1.txt", type: "added", localContent: "content1" },
+    ];
+
+    mockConfirm.mockResolvedValueOnce(true);
+    mockCheckbox.mockResolvedValueOnce(files);
+
+    setTimeout(() => {
+      simulateKeypress({ name: "return" });
+    }, 10);
+
+    await promptSelectFilesWithDiff(files);
+
+    // cleanup が呼ばれる（setRawMode(false) と resume）
+    expect(mockStdin.setRawMode).toHaveBeenCalledWith(false);
+  });
+
+  it("最初のファイルで p を押しても移動しない", async () => {
+    const files: FileDiff[] = [
+      { path: "file1.txt", type: "added", localContent: "content1" },
+      { path: "file2.txt", type: "modified", localContent: "new", templateContent: "old" },
+    ];
+
+    mockConfirm.mockResolvedValueOnce(true);
+    mockCheckbox.mockResolvedValueOnce(files);
+
+    setTimeout(() => {
+      simulateKeypress({ name: "p" }); // 最初なので移動しない
+      setTimeout(() => {
+        simulateKeypress({ name: "q" });
+      }, 10);
+    }, 10);
+
+    await promptSelectFilesWithDiff(files);
+
+    // file1 が1回だけ表示される（p を押しても移動しない）
+    const file1Calls = mockShowFileDiffBox.mock.calls.filter(
+      (call) => call[0].path === "file1.txt",
+    );
+    expect(file1Calls.length).toBe(1);
+  });
+
+  it("最後のファイルで n を押しても移動しない", async () => {
+    const files: FileDiff[] = [
+      { path: "file1.txt", type: "added", localContent: "content1" },
+    ];
+
+    mockConfirm.mockResolvedValueOnce(true);
+    mockCheckbox.mockResolvedValueOnce(files);
+
+    setTimeout(() => {
+      simulateKeypress({ name: "n" }); // 最後なので移動しない
+      setTimeout(() => {
+        simulateKeypress({ name: "q" });
+      }, 10);
+    }, 10);
+
+    await promptSelectFilesWithDiff(files);
+
+    // file1 が1回だけ表示される
+    expect(mockShowFileDiffBox).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleanup 後は次の @inquirer/prompts が使えるよう stdin が復元される", async () => {
+    const files: FileDiff[] = [
+      { path: "file1.txt", type: "added", localContent: "content1" },
+    ];
+
+    mockConfirm.mockResolvedValueOnce(true);
+    mockCheckbox.mockResolvedValueOnce(files);
+
+    setTimeout(() => {
+      simulateKeypress({ name: "q" });
+    }, 10);
+
+    await promptSelectFilesWithDiff(files);
+
+    // cleanup で stdin.resume() が呼ばれる
+    // setRawMode(true) → setRawMode(false) の順で呼ばれる
+    const setRawModeCalls = mockStdin.setRawMode.mock.calls;
+    expect(setRawModeCalls).toContainEqual([true]);
+    expect(setRawModeCalls).toContainEqual([false]);
   });
 });

--- a/packages/create-devenv/src/prompts/push.ts
+++ b/packages/create-devenv/src/prompts/push.ts
@@ -152,13 +152,17 @@ async function interactiveDiffViewer(files: FileDiff[]): Promise<void> {
         try {
           process.stdin.setRawMode(false);
         } catch {
-          // setRawMode エラーは無視
+          console.error(
+            "ターミナルの raw モード解除に失敗しました。ターミナルが正常に動作しない場合は `reset` コマンドを実行してください。",
+          );
         }
         try {
           // 次の @inquirer/prompts が使えるよう stdin を resume 状態に戻す
           process.stdin.resume();
         } catch {
-          // resume エラーは無視
+          console.error(
+            "標準入力の再開に失敗しました。後続のプロンプトが正常に動作しない可能性があります。",
+          );
         }
       };
 
@@ -204,8 +208,12 @@ async function interactiveDiffViewer(files: FileDiff[]): Promise<void> {
       process.stdin.on("keypress", handleKeypress);
 
       showCurrentDiff();
-    } catch {
+    } catch (error) {
       // セットアップ失敗時はフォールバック（非インタラクティブ表示）
+      console.error(
+        "インタラクティブ diff ビューアのセットアップに失敗しました。非インタラクティブモードで表示します。",
+        error,
+      );
       files.forEach((file, i) => {
         showFileDiffBox(file, i, files.length, { showLineNumbers: true });
       });


### PR DESCRIPTION
## Summary

 

`@inquirer/prompts` 使用後にインタラクティブ diff ビューワーがクラッシュする問題を修正しました。

 

### 問題

 

`npx @tktco/create-devenv` でコマンド選択後、diff ビューワーを表示するとツールがクラッシュ・ハングする。

 

### 根本原因

 

`@inquirer/prompts` の `select` プロンプトが終了後、stdin が不整合な状態で残される。その後 `readline.emitKeypressEvents` を呼ぶと、既存のリスナーと競合してクラッシュが発生。

 

### 修正内容

 

```typescript

// @inquirer/prompts が残した状態をリセット

process.stdin.removeAllListeners("keypress");

 

// stdin をセットアップ

readline.emitKeypressEvents(process.stdin);

process.stdin.setRawMode(true);

process.stdin.resume();

```

 

- `removeAllListeners("keypress")`: 既存のリスナーを削除して競合を防止

- `resume()`: stdin を確実にアクティブな状態に復元

- cleanup で `resume()` を呼び、次の `@inquirer/prompts` が正常に動作するよう復元

 

## Test plan

 

- [x] 既存テスト通過（319 → 327 tests）

- [x] 新規テスト追加（8件）

  - TTY 検出と non-TTY フォールバック

  - stdin リスナーリセット（`removeAllListeners`）

  - `readline.emitKeypressEvents` 呼び出し

  - キーボードナビゲーション（n/p/Enter/q）

  - 境界条件（最初/最後のファイル）

  - cleanup と stdin 状態の復元

- [ ] 手動テスト: `npx @tktco/create-devenv` → diff 選択 → インタラクティブビューワー操作