### PR TITLE
ci(create-devenv): add vitest test job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,25 @@ jobs:
           ls -la /tmp/test-project
           cat /tmp/test-project/.devenv.json
 
+  test:
+    name: Test (vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm --filter @tktco/create-devenv run test:run
+
   docs:
     name: Check README
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- CIワークフローに vitest テストジョブを追加
- テストファイル（18ファイル、322テスト）が存在するにも関わらず、CIでテストが実行されていなかった問題を修正

## Changes
- `.github/workflows/ci.yml` に `test` ジョブを追加
- `pnpm --filter @tktco/create-devenv run test:run` を実行

## Test plan
- [ ] CI ワークフローが正常に実行されることを確認
- [ ] vitest テストジョブが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)