### PR TITLE
ci: run CI on changeset release PR via workflow_call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
       - "packages/create-devenv/**"
       - ".github/workflows/ci.yml"
       - "pnpm-lock.yaml"
+  workflow_call:
+    # Called from release.yml when changeset PR is created/updated
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+
+    outputs:
+      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
+      pullRequestNumber: ${{ steps.changesets.outputs.pullRequestNumber }}
+
+  # Run CI on changeset release PR since GITHUB_TOKEN commits don't trigger workflows
+  ci-on-release-pr:
+    name: CI on Release PR
+    needs: release
+    if: needs.release.outputs.hasChangesets == 'true' && needs.release.outputs.pullRequestNumber != ''
+    uses: ./.github/workflows/ci.yml


### PR DESCRIPTION
## Summary

- Changeset release PR (#52) で CI が自動実行されるように設定
- `GITHUB_TOKEN` で作成されたコミットはワークフローをトリガーしないため、Release ワークフローから CI を直接呼び出すように変更

## 変更内容

- `ci.yml` に `workflow_call` トリガーを追加
- `release.yml` で changeset PR 作成時に CI を呼び出すジョブを追加

## 動作フロー

```
main へ push
    ↓
Release ワークフロー起動
    ↓
Changesets action が PR を作成/更新
    ↓
ci-on-release-pr ジョブが CI を呼び出す
    ↓
CI (lint, format, typecheck, build, test, docs) が実行される
```

## Test plan

- [ ] この PR をマージ後、main に changeset を含むコミットを push
- [ ] Release ワークフローが実行され、changeset PR が更新される
- [ ] 同じ Release ワークフロー内で CI ジョブが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)