### PR TITLE
ci: remove paths filter for pull_request trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,6 @@ on:
       - "pnpm-lock.yaml"
   pull_request:
     branches: [main]
-    paths:
-      - "packages/create-devenv/**"
-      - ".github/workflows/ci.yml"
-      - "pnpm-lock.yaml"
   workflow_call:
     # Called from release.yml when changeset PR is created/updated
 


### PR DESCRIPTION
## Summary
- PRトリガーから `paths` フィルタを削除し、PRでは常にCIが実行されるように変更
- これにより、Required Status Checks と オートマージ機能が正常に連携できるようになる

## Background
以前の設定では、`paths` フィルタにより特定のパス外のファイルのみを変更したPRではCIがスキップされていました。これにより Required Status Checks が pending のままとなり、オートマージがブロックされる問題がありました。

## Changes
- `pull_request` トリガーから `paths` フィルタを削除
- `push` (mainブランチ) のパスフィルタは維持

## Test plan
- [ ] PRが作成された時点でCIが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)