### PR TITLE
feat: add ai-docs command for LLM-friendly documentation

### DIFF
--- a/.changeset/add-llm-instructions.md
+++ b/.changeset/add-llm-instructions.md
@@ -1,0 +1,11 @@
+---
+"@tktco/create-devenv": minor
+---
+
+feat(create-devenv): add ai-docs command for LLM-friendly documentation
+
+- Add `ai-docs` subcommand that outputs comprehensive documentation for AI coding agents
+- Create unified documentation source (src/docs/ai-guide.ts) for both CLI and README
+- Add "For AI Agents" section to README with non-interactive workflow instructions
+- Integrate ai-docs command into CLI help output
+

--- a/packages/create-devenv/README.md
+++ b/packages/create-devenv/README.md
@@ -113,7 +113,41 @@ OPTIONS
   `-v, --verbose`    Show detailed diff
 ```
 
+### `ai-docs`
+
+Show documentation for AI coding agents
+
+```
+Show documentation for AI coding agents (ai-docs)
+
+USAGE `ai-docs `
+```
+
 <!-- COMMANDS:END -->
+
+<!-- AI_AGENTS:START -->
+
+## For AI Agents
+
+AI coding agents can use the non-interactive workflow:
+
+```bash
+# 1. Generate manifest file
+npx @tktco/create-devenv push --prepare
+
+# 2. Edit .devenv-push-manifest.yaml to select files and set PR details
+
+# 3. Create PR from manifest
+npx @tktco/create-devenv push --execute
+```
+
+For detailed documentation, run:
+
+```bash
+npx @tktco/create-devenv ai-docs
+```
+
+<!-- AI_AGENTS:END -->
 
 <!-- FILES:START -->
 

--- a/packages/create-devenv/scripts/generate-readme.ts
+++ b/packages/create-devenv/scripts/generate-readme.ts
@@ -23,9 +23,11 @@ import { resolve } from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import { renderUsage } from "citty";
 import { parse } from "jsonc-parser";
+import { aiDocsCommand } from "../src/commands/ai-docs";
 import { diffCommand } from "../src/commands/diff";
 import { initCommand } from "../src/commands/init";
 import { pushCommand } from "../src/commands/push";
+import { generateReadmeSection as generateAiAgentsSection } from "../src/docs/ai-guide";
 
 const README_PATH = resolve(import.meta.dirname, "../README.md");
 const MODULES_PATH = resolve(import.meta.dirname, "../../../.devenv/modules.jsonc");
@@ -43,6 +45,10 @@ const MARKERS = {
   commands: {
     start: "<!-- COMMANDS:START -->",
     end: "<!-- COMMANDS:END -->",
+  },
+  aiAgents: {
+    start: "<!-- AI_AGENTS:START -->",
+    end: "<!-- AI_AGENTS:END -->",
   },
   files: {
     start: "<!-- FILES:START -->",
@@ -147,6 +153,13 @@ async function generateCommandsSection(): Promise<string> {
   sections.push(cleanUsageOutput(await renderUsage(diffCommand)));
   sections.push("```\n");
 
+  // ai-docs command
+  sections.push("### `ai-docs`\n");
+  sections.push(`${getCommandDescription(aiDocsCommand.meta)}\n`);
+  sections.push("```");
+  sections.push(cleanUsageOutput(await renderUsage(aiDocsCommand)));
+  sections.push("```\n");
+
   return sections.join("\n");
 }
 
@@ -229,6 +242,7 @@ async function main(): Promise<void> {
   const usageSection = generateUsageSection();
   const featuresSection = generateFeaturesSection(modules);
   const commandsSection = await generateCommandsSection();
+  const aiAgentsSection = generateAiAgentsSection();
   const filesSection = generateFilesSection(modules);
 
   // Update README
@@ -238,6 +252,7 @@ async function main(): Promise<void> {
   readme = updateSection(readme, MARKERS.usage.start, MARKERS.usage.end, usageSection);
   readme = updateSection(readme, MARKERS.features.start, MARKERS.features.end, featuresSection);
   readme = updateSection(readme, MARKERS.commands.start, MARKERS.commands.end, commandsSection);
+  readme = updateSection(readme, MARKERS.aiAgents.start, MARKERS.aiAgents.end, aiAgentsSection);
   readme = updateSection(readme, MARKERS.files.start, MARKERS.files.end, filesSection);
 
   const updated = readme !== originalReadme;

--- a/packages/create-devenv/src/commands/ai-docs.ts
+++ b/packages/create-devenv/src/commands/ai-docs.ts
@@ -1,0 +1,14 @@
+import { defineCommand } from "citty";
+import { generateAiGuideWithHeader } from "../docs/ai-guide";
+
+export const aiDocsCommand = defineCommand({
+  meta: {
+    name: "ai-docs",
+    description: "Show documentation for AI coding agents",
+  },
+  args: {},
+  run() {
+    // Output markdown directly to stdout for easy piping/reading by AI agents
+    console.log(generateAiGuideWithHeader());
+  },
+});

--- a/packages/create-devenv/src/docs/ai-guide.ts
+++ b/packages/create-devenv/src/docs/ai-guide.ts
@@ -1,0 +1,164 @@
+/**
+ * AI Agent Guide
+ *
+ * This file serves as the single source of truth for AI-facing documentation.
+ * It is used both for:
+ *   - `create-devenv ai-docs` command output
+ *   - README.md "For AI Agents" section generation
+ */
+
+import { version } from "../../package.json";
+import { MANIFEST_FILENAME } from "../utils/manifest";
+
+export interface DocSection {
+  title: string;
+  content: string;
+}
+
+/**
+ * Generate the complete AI agent guide as markdown
+ */
+export function generateAiGuide(): string {
+  const sections = getDocSections();
+  return sections.map((s) => `## ${s.title}\n\n${s.content}`).join("\n\n");
+}
+
+/**
+ * Generate the AI agent guide with header for CLI output
+ */
+export function generateAiGuideWithHeader(): string {
+  const header = `# create-devenv v${version} - AI Agent Guide
+
+This guide explains how AI coding agents (Claude Code, Cursor, etc.) can use this tool effectively.
+`;
+
+  return header + "\n" + generateAiGuide();
+}
+
+/**
+ * Get individual documentation sections
+ * Used by both CLI output and README generation
+ */
+export function getDocSections(): DocSection[] {
+  return [
+    {
+      title: "Quick Reference",
+      content: `\`\`\`bash
+# Non-interactive push workflow for AI agents
+npx @tktco/create-devenv push --prepare    # Generate manifest
+# Edit ${MANIFEST_FILENAME}              # Select files
+npx @tktco/create-devenv push --execute    # Create PR
+
+# Other commands
+npx @tktco/create-devenv init [dir]        # Apply template (interactive)
+npx @tktco/create-devenv diff              # Show differences
+\`\`\``,
+    },
+    {
+      title: "Push Workflow for AI Agents",
+      content: `When contributing template improvements, use the two-phase workflow:
+
+### Phase 1: Prepare
+
+\`\`\`bash
+npx @tktco/create-devenv push --prepare
+\`\`\`
+
+This generates \`${MANIFEST_FILENAME}\` containing:
+- List of changed files with \`selected: true/false\`
+- PR title and body fields
+- Summary of changes
+
+### Phase 2: Edit Manifest
+
+Edit the generated \`${MANIFEST_FILENAME}\`:
+
+\`\`\`yaml
+pr:
+  title: "feat: add new workflow for CI"
+  body: |
+    ## Summary
+    Added new CI workflow for automated testing.
+
+    ## Changes
+    - Added .github/workflows/ci.yml
+
+files:
+  - path: .github/workflows/ci.yml
+    type: added
+    selected: true    # Include this file
+  - path: .github/labeler.yml
+    type: modified
+    selected: false   # Exclude this file
+\`\`\`
+
+### Phase 3: Execute
+
+\`\`\`bash
+# Set GitHub token (required)
+export GITHUB_TOKEN="your-token"
+
+# Create the PR
+npx @tktco/create-devenv push --execute
+\`\`\``,
+    },
+    {
+      title: "Manifest File Reference",
+      content: `The manifest file (\`${MANIFEST_FILENAME}\`) structure:
+
+| Field | Description |
+|-------|-------------|
+| \`version\` | Manifest format version (always \`1\`) |
+| \`generated_at\` | ISO 8601 timestamp |
+| \`github.token\` | GitHub token (prefer env var) |
+| \`pr.title\` | PR title (editable) |
+| \`pr.body\` | PR description (editable) |
+| \`files[].path\` | File path |
+| \`files[].type\` | \`added\` / \`modified\` / \`deleted\` |
+| \`files[].selected\` | Include in PR (\`true\`/\`false\`) |
+| \`untracked_files[]\` | Files outside whitelist (default: \`selected: false\`) |
+| \`summary\` | Change statistics |`,
+    },
+    {
+      title: "Environment Variables",
+      content: `| Variable | Description |
+|----------|-------------|
+| \`GITHUB_TOKEN\` | GitHub personal access token (required for push) |
+| \`GH_TOKEN\` | Alternative to GITHUB_TOKEN |
+
+The token needs \`repo\` scope for creating PRs.`,
+    },
+    {
+      title: "Best Practices for AI Agents",
+      content: `1. **Always use \`--prepare\` then \`--execute\`** for non-interactive operation
+2. **Review the diff first** with \`npx @tktco/create-devenv diff\`
+3. **Set meaningful PR titles** that follow conventional commits (e.g., \`feat:\`, \`fix:\`, \`docs:\`)
+4. **Deselect unrelated changes** by setting \`selected: false\`
+5. **Use environment variables** for tokens instead of hardcoding in manifest`,
+    },
+  ];
+}
+
+/**
+ * Generate README section for AI agents
+ * Returns content suitable for embedding in README.md
+ */
+export function generateReadmeSection(): string {
+  const lines: string[] = [];
+  lines.push("## For AI Agents\n");
+  lines.push("AI coding agents can use the non-interactive workflow:\n");
+  lines.push("```bash");
+  lines.push("# 1. Generate manifest file");
+  lines.push("npx @tktco/create-devenv push --prepare");
+  lines.push("");
+  lines.push(`# 2. Edit ${MANIFEST_FILENAME} to select files and set PR details`);
+  lines.push("");
+  lines.push("# 3. Create PR from manifest");
+  lines.push("npx @tktco/create-devenv push --execute");
+  lines.push("```\n");
+  lines.push("For detailed documentation, run:\n");
+  lines.push("```bash");
+  lines.push("npx @tktco/create-devenv ai-docs");
+  lines.push("```\n");
+  return lines.join("\n");
+}

--- a/packages/create-devenv/src/index.ts
+++ b/packages/create-devenv/src/index.ts
@@ -2,6 +2,7 @@
 import { select } from "@inquirer/prompts";
 import { defineCommand, runMain } from "citty";
 import { version } from "../package.json";
+import { aiDocsCommand } from "./commands/ai-docs";
 import { diffCommand } from "./commands/diff";
 import { initCommand } from "./commands/init";
 import { pushCommand } from "./commands/push";
@@ -17,6 +18,7 @@ const main = defineCommand({
     init: initCommand,
     push: pushCommand,
     diff: diffCommand,
+    "ai-docs": aiDocsCommand,
   },
 });
 
@@ -62,7 +64,8 @@ async function promptCommand(): Promise<void> {
 // サブコマンドなしで実行された場合の処理
 const args = process.argv.slice(2);
 const hasSubCommand =
-  args.length > 0 && ["init", "push", "diff", "--help", "-h", "--version", "-v"].includes(args[0]);
+  args.length > 0 &&
+  ["init", "push", "diff", "ai-docs", "--help", "-h", "--version", "-v"].includes(args[0]);
 
 if (!hasSubCommand && args.length > 0 && !args[0].startsWith("-")) {
   // npx @tktco/create-devenv . のような形式は init コマンドとして実行


### PR DESCRIPTION
## Summary

This PR adds an `ai-docs` subcommand that outputs comprehensive documentation tailored for AI coding agents (Claude Code, Cursor, etc.). It establishes a single source of truth for AI-facing documentation that is used both by the CLI command and the README.

## Key Changes

- **New `ai-docs` command** (`src/commands/ai-docs.ts`): Outputs markdown documentation optimized for AI agents to understand the tool's non-interactive workflow
- **Unified documentation source** (`src/docs/ai-guide.ts`): Centralized documentation that serves both the CLI output and README generation, including:
  - Quick reference for common commands
  - Detailed push workflow for AI agents (prepare → edit manifest → execute)
  - Manifest file format reference
  - Environment variable documentation
  - Best practices for AI agents
- **README updates**: Added "For AI Agents" section with quick-start instructions and link to full documentation
- **CLI integration**: Registered `ai-docs` command in main CLI and updated subcommand detection logic
- **Build script updates** (`scripts/generate-readme.ts`): Integrated AI agents section generation into the README generation pipeline

## Implementation Details

- The `ai-guide.ts` module exports multiple functions to support different use cases:
  - `generateAiGuide()`: Core documentation content
  - `generateAiGuideWithHeader()`: Full output with version header for CLI
  - `getDocSections()`: Individual sections for flexible composition
  - `generateReadmeSection()`: README-specific formatting
- Documentation emphasizes the non-interactive two-phase workflow (`--prepare` and `--execute`) which is essential for AI agents that cannot interact with prompts
- All documentation is automatically kept in sync via the README generation script