### PR TITLE
Add AI agent hint to default command output

### DIFF
--- a/.changeset/ai-hint-default-command.md
+++ b/.changeset/ai-hint-default-command.md
@@ -1,0 +1,7 @@
+---
+"@tktco/create-devenv": patch
+---
+
+Show AI agent hint in default command output
+
+When running `create-devenv` without arguments, the output now includes a hint for AI agents pointing them to the `ai-docs` command for non-interactive usage documentation.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.5/schema.json",
-  "changelog": [
-    "@changesets/changelog-github",
-    { "repo": "tktcorporation/.github" }
-  ],
+  "changelog": ["@changesets/changelog-github", { "repo": "tktcorporation/.github" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,11 +12,7 @@
     ]
   },
   "enableAllProjectMcpServers": true,
-  "enabledMcpjsonServers": [
-    "chrome-devtools",
-    "ide",
-    "context7"
-  ],
+  "enabledMcpjsonServers": ["chrome-devtools", "ide", "context7"],
   "enabledPlugins": {
     "document-skills@anthropic-agent-skills": true,
     "example-skills@anthropic-agent-skills": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -69,13 +69,7 @@
     "mise-install": "mise install"
   },
   "postStartCommand": {
-    "setup-chrome-devtools-mcp": [
-      "bash",
-      "-lc",
-      ".devcontainer/setup-chrome-devtools-mcp.sh"
-    ],
-    "mise-upgrade": [
-      "mise", "upgrade"
-    ]
+    "setup-chrome-devtools-mcp": ["bash", "-lc", ".devcontainer/setup-chrome-devtools-mcp.sh"],
+    "mise-upgrade": ["mise", "upgrade"]
   }
 }

--- a/.devenv/modules.jsonc
+++ b/.devenv/modules.jsonc
@@ -7,10 +7,7 @@
       "name": "Root",
       "description": "MCP, mise, and other root-level config files",
       "setupDescription": "Root config files will be applied",
-      "patterns": [
-        ".mcp.json",
-        ".mise.toml"
-      ]
+      "patterns": [".mcp.json", ".mise.toml"],
     },
     {
       "id": ".devcontainer",
@@ -24,8 +21,8 @@
         ".devcontainer/setup-*.sh",
         ".devcontainer/test-*.sh",
         ".devcontainer/.env.devcontainer.example",
-        ".devcontainer/run-chrome-devtools-mcp.sh"
-      ]
+        ".devcontainer/run-chrome-devtools-mcp.sh",
+      ],
     },
     {
       "id": ".github",
@@ -35,9 +32,9 @@
       "patterns": [
         ".github/workflows/issue-link.yml",
         ".github/workflows/label.yml",
-        ".github/labeler.yml"
+        ".github/labeler.yml",
         // Excluded: ci.yml, release.yml (repo-specific CI/CD)
-      ]
+      ],
     },
     {
       "id": ".claude",
@@ -45,9 +42,9 @@
       "description": "Claude Code project settings",
       "setupDescription": "Claude Code project settings will be applied",
       "patterns": [
-        ".claude/settings.json"
+        ".claude/settings.json",
         // Excluded: settings.local.json (personal settings)
-      ]
-    }
-  ]
+      ],
+    },
+  ],
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -15,10 +15,7 @@
     "ide": {
       "type": "stdio",
       "command": "npx",
-      "args": [
-        "-y",
-        "@anthropic-ai/ide-mcp@latest"
-      ],
+      "args": ["-y", "@anthropic-ai/ide-mcp@latest"],
       "env": {}
     }
   }

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -14,7 +14,7 @@
 # The first language is the default language and the respective language server will be used as a fallback.
 # Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
 languages:
-- bash
+  - bash
 
 # the encoding used by text files in the project
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
@@ -37,7 +37,7 @@ read_only: false
 
 # list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
 # Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
+# To make sure you have the latest list of tools, and to view their descriptions,
 # execute `uv run scripts/print_tool_overview.py`.
 #
 #  * `activate_project`: Activates a project by name.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,13 @@ pnpm workspaces を使用したモノレポ構成のプロジェクトです。
   - changeset はリリースノートとバージョン管理に使用されます
   - patch / minor / major を適切に選択してください
 
+### PR を作成する前に
+
+- **CI チェックをローカルで通してからプッシュ・PR作成してください**
+  - `npx oxfmt --check .` でフォーマットチェック（失敗したら `npx oxfmt --write .` で修正）
+  - `pnpm build` でビルド確認
+  - `pnpm test` でテスト通過確認
+
 ### コマンド
 
 ```bash
@@ -22,6 +29,15 @@ pnpm install
 
 # ビルド
 pnpm build
+
+# フォーマットチェック（CI と同じ）
+npx oxfmt --check .
+
+# フォーマット修正
+npx oxfmt --write .
+
+# テスト
+pnpm test
 
 # changeset の追加
 pnpm changeset add

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "tktcorporation-github",
   "private": true,
-  "packageManager": "pnpm@10.25.0",
   "scripts": {
     "version": "changeset version",
     "release": "changeset publish"
@@ -10,5 +9,6 @@
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.29.8",
     "rollup": "^4.53.3"
-  }
+  },
+  "packageManager": "pnpm@10.25.0"
 }

--- a/packages/create-devenv/CHANGELOG.md
+++ b/packages/create-devenv/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Minor Changes
 
 - [#65](https://github.com/tktcorporation/.github/pull/65) [`03464f3`](https://github.com/tktcorporation/.github/commit/03464f39cf516de0e0018c58a5ab37246fa94764) Thanks [@tktcorporation](https://github.com/tktcorporation)! - feat(create-devenv): add ai-docs command for LLM-friendly documentation
-
   - Add `ai-docs` subcommand that outputs comprehensive documentation for AI coding agents
   - Create unified documentation source (src/docs/ai-guide.ts) for both CLI and README
   - Add "For AI Agents" section to README with non-interactive workflow instructions
@@ -16,7 +15,6 @@
 ### Minor Changes
 
 - [#61](https://github.com/tktcorporation/.github/pull/61) [`41ea99b`](https://github.com/tktcorporation/.github/commit/41ea99b9c0ed8f9fbe88c976735577cece92636c) Thanks [@tktcorporation](https://github.com/tktcorporation)! - Add AI-agent friendly manifest-based push workflow
-
   - `--prepare` option: Generates a YAML manifest file (`.devenv-push-manifest.yaml`) for reviewing and editing file selections
   - `--execute` option: Creates a PR based on the manifest file without interactive prompts
 
@@ -27,7 +25,6 @@
 ### Patch Changes
 
 - [#51](https://github.com/tktcorporation/.github/pull/51) [`71d6e04`](https://github.com/tktcorporation/.github/commit/71d6e04edd297f79e56d1a6df40262da2e22d2a4) Thanks [@tktcorporation](https://github.com/tktcorporation)! - feat(init): gitignore 対象ファイルの同期時の挙動を改善
-
   - init 時に gitignore 対象のファイルがローカルに既存在する場合、上書きせずスキップして警告を表示
   - gitignore 対象のファイルがローカルに存在しない場合は、通常通りコピー
   - push 時は gitignore 対象ファイルを追跡対象から除外（既存の動作を維持）
@@ -35,7 +32,6 @@
   これにより、ローカルで編集した gitignore 対象ファイル（環境設定など）がテンプレート同期時に上書きされることを防止します。
 
 - [#50](https://github.com/tktcorporation/.github/pull/50) [`f70e506`](https://github.com/tktcorporation/.github/commit/f70e50601bcedb3a19054463b11b6e77d83df3c8) Thanks [@tktcorporation](https://github.com/tktcorporation)! - fix(create-devenv): fix stdin conflict between @inquirer/prompts and interactive diff viewer
-
   - Clear existing keypress listeners before setting up interactive viewer to prevent conflicts with @inquirer/prompts
   - Call stdin.resume() to ensure stdin is in correct state after @inquirer/prompts usage
   - Properly restore stdin state in cleanup for subsequent prompts
@@ -45,14 +41,12 @@
 ### Minor Changes
 
 - [#45](https://github.com/tktcorporation/.github/pull/45) [`4557ba0`](https://github.com/tktcorporation/.github/commit/4557ba09b019d2f8f0dbaad3f274d6c4e56c9731) Thanks [@tktcorporation](https://github.com/tktcorporation)! - feat(create-devenv): improve diff display with summary box and interactive viewer
-
   - Add new diff-viewer.ts with modern box-styled summary display
   - Show file changes grouped by type (added/modified/deleted) with line stats
   - Add interactive diff viewer with n/p navigation between files
   - Improve file selection UI with stats display
 
 - [#45](https://github.com/tktcorporation/.github/pull/45) [`09b8e2e`](https://github.com/tktcorporation/.github/commit/09b8e2ebc31d44e1a771ef034fc8c5ed7a1e8edc) Thanks [@tktcorporation](https://github.com/tktcorporation)! - feat(create-devenv): add word-level diff and syntax highlighting
-
   - Word-level diff: highlight changed words with background colors
   - Syntax highlighting: automatic language detection based on file extension
   - Supports 30+ languages including TypeScript, JavaScript, JSON, YAML, etc.
@@ -60,7 +54,6 @@
 ### Patch Changes
 
 - [#47](https://github.com/tktcorporation/.github/pull/47) [`052075d`](https://github.com/tktcorporation/.github/commit/052075dd830d4ccc8eae4b949a73db164e903df7) Thanks [@tktcorporation](https://github.com/tktcorporation)! - テストを大幅に拡充
-
   - config.ts: 設定ファイルの読み書きテスト
   - patterns.ts: パターンマッチングとマージのテスト
   - modules/schemas.ts: Zod スキーマバリデーションテスト
@@ -78,7 +71,6 @@
 ### Minor Changes
 
 - [#43](https://github.com/tktcorporation/.github/pull/43) [`6685140`](https://github.com/tktcorporation/.github/commit/66851404ab3aa2bb325dcf642460648213f56d2c) Thanks [@tktcorporation](https://github.com/tktcorporation)! - Improve CLI output with modern, user-friendly design
-
   - Add step-by-step progress indicators (e.g., [1/3], [2/3])
   - Add spinners for async operations (template download, diff detection)
   - Improve file operation results display with colored icons
@@ -93,7 +85,6 @@
 ### Patch Changes
 
 - [#34](https://github.com/tktcorporation/.github/pull/34) [`d142d5a`](https://github.com/tktcorporation/.github/commit/d142d5ad3b091ad33c1532c701c3b52609739bed) Thanks [@tktcorporation](https://github.com/tktcorporation)! - ツールチェーンを oxc エコシステムに移行
-
   - Biome → oxlint + oxfmt に移行
   - tsc --noEmit → oxlint --type-check に移行
   - unbuild → tsdown に移行
@@ -123,20 +114,17 @@
 - [#23](https://github.com/tktcorporation/.github/pull/23) [`ec36c47`](https://github.com/tktcorporation/.github/commit/ec36c474aac4e01b30ad018507f5fe7f9a305da2) Thanks [@tktcorporation](https://github.com/tktcorporation)! - push コマンドにホワイトリスト外ファイル検知機能を追加し、モジュール定義を外部化
 
   ### ホワイトリスト外ファイル検知
-
   - push 時にホワイトリスト（patterns）に含まれていないファイルを検出
   - モジュールごとにグループ化して選択 UI を表示
   - 選択したファイルを modules.jsonc に自動追加（PR に含まれる）
   - gitignore されているファイルは自動で除外
 
   ### モジュール定義の外部化
-
   - モジュール定義をコードから `.devenv/modules.jsonc` に外部化
   - テンプレートリポジトリの modules.jsonc から動的に読み込み
   - `customPatterns` を廃止し modules.jsonc に統合
 
   ### ディレクトリベースのモジュール設計
-
   - モジュール ID をディレクトリパスベースに変更（例: `.devcontainer`, `.github`, `.`）
   - ファイルパスから即座にモジュール ID を導出可能に
   - モジュール間のファイル重複を構造的に防止
@@ -146,7 +134,6 @@
 ### Minor Changes
 
 - [#14](https://github.com/tktcorporation/.github/pull/14) [`c026ed5`](https://github.com/tktcorporation/.github/commit/c026ed55da57df6599f7c57cdbb5d29c05e3273d) Thanks [@tktcorporation](https://github.com/tktcorporation)! - .gitignore に記載されたファイルを自動的に除外する機能を追加
-
   - init, diff, push の全コマンドで .gitignore にマッチするファイルを除外
   - ローカルディレクトリとテンプレートリポジトリ両方の .gitignore をチェック
   - クレデンシャル等の機密情報の誤流出を防止
@@ -163,12 +150,10 @@
 - [#12](https://github.com/tktcorporation/.github/pull/12) [`798d3fb`](https://github.com/tktcorporation/.github/commit/798d3fb332bdffbc4feac24d9ed89a1b510d7fcf) Thanks [@tktcorporation](https://github.com/tktcorporation)! - 双方向同期機能とホワイトリスト形式を追加
 
   ### 新機能
-
   - `push` コマンド: ローカル変更を GitHub PR として自動送信
   - `diff` コマンド: ローカルとテンプレートの差分をプレビュー
 
   ### 破壊的変更
-
   - モジュール定義を `files` + `excludeFiles` 形式から `patterns` (glob) 形式に移行
   - テンプレート対象ファイルをホワイトリスト形式で明示的に指定するように変更
 
@@ -204,7 +189,6 @@
 ### Patch Changes
 
 - [#4](https://github.com/tktcorporation/.github/pull/4) [`ae7c5e7`](https://github.com/tktcorporation/.github/commit/ae7c5e712b1a16963cd0cd920a92dd589f5e9f84) Thanks [@tktcorporation](https://github.com/tktcorporation)! - fix: overwriteStrategy オプションが正しく機能するように修正
-
   - "prompt" 戦略: ファイルごとにユーザーに上書き確認を表示
   - "skip" 戦略: 既存ファイルをスキップして新規ファイルのみコピー
   - "overwrite" 戦略: 既存ファイルを全て上書き

--- a/packages/create-devenv/src/index.ts
+++ b/packages/create-devenv/src/index.ts
@@ -35,15 +35,11 @@ const commandMap: Record<"init" | "push" | "diff", CommandType> = {
  */
 function showAiHint(): void {
   log.newline();
-  console.log(
-    pc.dim("─".repeat(40)),
-  );
+  console.log(pc.dim("─".repeat(40)));
   console.log(
     `${pc.dim("🤖 Are you an AI agent?")} Run ${pc.cyan("npx @tktco/create-devenv ai-docs")} for non-interactive usage guide.`,
   );
-  console.log(
-    pc.dim("─".repeat(40)),
-  );
+  console.log(pc.dim("─".repeat(40)));
   log.newline();
 }
 

--- a/packages/create-devenv/src/index.ts
+++ b/packages/create-devenv/src/index.ts
@@ -31,10 +31,28 @@ const commandMap: Record<"init" | "push" | "diff", CommandType> = {
 };
 
 /**
+ * AI エージェント向けのヒントを表示
+ */
+function showAiHint(): void {
+  log.newline();
+  console.log(
+    pc.dim("─".repeat(40)),
+  );
+  console.log(
+    `${pc.dim("🤖 Are you an AI agent?")} Run ${pc.cyan("npx @tktco/create-devenv ai-docs")} for non-interactive usage guide.`,
+  );
+  console.log(
+    pc.dim("─".repeat(40)),
+  );
+  log.newline();
+}
+
+/**
  * コマンド選択プロンプト
  */
 async function promptCommand(): Promise<void> {
   showHeader("create-devenv", version);
+  showAiHint();
 
   log.info("Select a command to run:");
   log.newline();


### PR DESCRIPTION
## Summary
This PR adds a helpful hint for AI agents when running `create-devenv` without arguments. The hint directs AI agents to use the `ai-docs` command for non-interactive usage documentation.

## Changes
- Added `showAiHint()` function that displays a formatted message with AI agent guidance
- Integrated the hint into the default command prompt flow, displayed after the header
- The hint includes a direct reference to the `npx @tktco/create-devenv ai-docs` command for easy discovery

## Implementation Details
- The hint is styled with visual separators (─ characters) and uses color coding (dim text for borders, cyan for the command)
- Positioned strategically after the header but before the command selection prompt to ensure visibility
- Uses existing logging utilities (`log.newline()`, `pc.dim()`, `pc.cyan()`) for consistency with the codebase

https://claude.ai/code/session_01GnMvpVQx7RQPwcQdUcmwvW