### PR TITLE
feat: add `track` command for non-interactive file pattern management

### DIFF
--- a/.changeset/brave-rocks-track.md
+++ b/.changeset/brave-rocks-track.md
@@ -1,0 +1,13 @@
+---
+"@tktco/create-devenv": minor
+---
+
+feat: add `track` command for non-interactive file tracking management
+
+AIエージェントが非インタラクティブにファイルパターンを `.devenv/modules.jsonc` のホワイトリストに追加できる `track` コマンドを追加。
+
+- `npx @tktco/create-devenv track ".cloud/rules/*.md"` でパターン追加（モジュール自動検出）
+- `--module` オプションで明示的にモジュール指定可能
+- 存在しないモジュールは自動作成（`--name`, `--description` でカスタマイズ可能）
+- `--list` で現在の追跡モジュール・パターン一覧を表示
+- AI agent guide にドキュメントを追加

--- a/packages/create-devenv/src/commands/__tests__/track.test.ts
+++ b/packages/create-devenv/src/commands/__tests__/track.test.ts
@@ -1,0 +1,143 @@
+import { vol } from "memfs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// fs モジュールをモック
+vi.mock("node:fs", async () => {
+  const memfs = await import("memfs");
+  return memfs.fs;
+});
+
+vi.mock("node:fs/promises", async () => {
+  const memfs = await import("memfs");
+  return memfs.fs.promises;
+});
+
+// utils/ui をモック
+vi.mock("../../utils/ui", () => ({
+  showHeader: vi.fn(),
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    dim: vi.fn(),
+    newline: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+  pc: {
+    bold: (s: string) => s,
+    cyan: (s: string) => s,
+    dim: (s: string) => s,
+    green: (s: string) => s,
+  },
+  box: vi.fn(),
+}));
+
+// console.log をモック
+vi.spyOn(console, "log").mockImplementation(() => {});
+
+// process.exit をモック
+vi.spyOn(process, "exit").mockImplementation(() => {
+  throw new Error("process.exit called");
+});
+
+// モック後にインポート
+const { loadModulesFile, saveModulesFile, modulesFileExists } = await import("../../modules");
+const { addPatternToModulesFileWithCreate } = await import("../../modules/loader");
+
+describe("track command - core logic", () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  describe("addPatternToModulesFileWithCreate", () => {
+    it("既存モジュールにパターンを追加できる", () => {
+      const rawContent = JSON.stringify(
+        {
+          modules: [
+            {
+              id: ".cloud",
+              name: "Cloud",
+              description: "Cloud files",
+              patterns: [".cloud/config.json"],
+            },
+          ],
+        },
+        null,
+        2,
+      );
+
+      const result = addPatternToModulesFileWithCreate(rawContent, ".cloud", [".cloud/rules/*.md"]);
+
+      const parsed = JSON.parse(result);
+      expect(parsed.modules[0].patterns).toContain(".cloud/config.json");
+      expect(parsed.modules[0].patterns).toContain(".cloud/rules/*.md");
+    });
+
+    it("新しいモジュールを作成してパターンを追加できる", () => {
+      const rawContent = JSON.stringify(
+        {
+          modules: [
+            {
+              id: ".",
+              name: "Root",
+              description: "Root files",
+              patterns: [".mcp.json"],
+            },
+          ],
+        },
+        null,
+        2,
+      );
+
+      const result = addPatternToModulesFileWithCreate(rawContent, ".cloud", [
+        ".cloud/rules/*.md",
+        ".cloud/config.json",
+      ]);
+
+      const parsed = JSON.parse(result);
+      expect(parsed.modules).toHaveLength(2);
+      expect(parsed.modules[1].id).toBe(".cloud");
+      expect(parsed.modules[1].name).toBe("Cloud");
+      expect(parsed.modules[1].patterns).toEqual([".cloud/rules/*.md", ".cloud/config.json"]);
+    });
+  });
+
+  describe("modules.jsonc の読み書き", () => {
+    it("パターン追加後にファイルを正しく保存できる", async () => {
+      const initialContent = JSON.stringify(
+        {
+          modules: [
+            {
+              id: ".",
+              name: "Root",
+              description: "Root files",
+              patterns: [".mcp.json"],
+            },
+          ],
+        },
+        null,
+        2,
+      );
+
+      vol.fromJSON({
+        "/project/.devenv/modules.jsonc": initialContent,
+      });
+
+      const { rawContent } = await loadModulesFile("/project");
+      const updated = addPatternToModulesFileWithCreate(rawContent, ".cloud", [
+        ".cloud/rules/*.md",
+      ]);
+      await saveModulesFile("/project", updated);
+
+      const saved = vol.readFileSync("/project/.devenv/modules.jsonc", "utf8") as string;
+      const parsed = JSON.parse(saved);
+      expect(parsed.modules).toHaveLength(2);
+      expect(parsed.modules[1].id).toBe(".cloud");
+    });
+
+    it("modules.jsonc が存在しない場合を検知できる", () => {
+      vol.fromJSON({});
+      expect(modulesFileExists("/project")).toBe(false);
+    });
+  });
+});

--- a/packages/create-devenv/src/commands/track.ts
+++ b/packages/create-devenv/src/commands/track.ts
@@ -1,0 +1,168 @@
+import { defineCommand } from "citty";
+import { resolve } from "pathe";
+import {
+  addPatternToModulesFileWithCreate,
+  loadModulesFile,
+  modulesFileExists,
+  saveModulesFile,
+} from "../modules";
+import { getModuleIdFromPath } from "../utils/untracked";
+import { box, log, pc, showHeader } from "../utils/ui";
+
+/**
+ * パターン文字列からモジュール ID を推定
+ * 例: ".cloud/rules/*.md" → ".cloud"
+ *     ".mcp.json" → "."
+ *     ".github/workflows/ci.yml" → ".github"
+ */
+function inferModuleId(pattern: string): string {
+  // glob のメタ文字を除いた先頭パスからモジュール ID を推定
+  const cleanPath = pattern.replace(/\*.*$/, "").replace(/\{.*$/, "");
+  return getModuleIdFromPath(cleanPath || pattern);
+}
+
+export const trackCommand = defineCommand({
+  meta: {
+    name: "track",
+    description: "Add file patterns to the tracking whitelist in modules.jsonc",
+  },
+  args: {
+    patterns: {
+      type: "positional",
+      description: "File paths or glob patterns to track (e.g., .cloud/rules/*.md)",
+      required: true,
+    },
+    dir: {
+      type: "string",
+      alias: "d",
+      description: "Project directory (default: current directory)",
+      default: ".",
+    },
+    module: {
+      type: "string",
+      alias: "m",
+      description: "Module ID to add patterns to (auto-detected from path if omitted)",
+    },
+    name: {
+      type: "string",
+      description: "Module name (used when creating a new module)",
+    },
+    description: {
+      type: "string",
+      description: "Module description (used when creating a new module)",
+    },
+    list: {
+      type: "boolean",
+      alias: "l",
+      description: "List all currently tracked modules and patterns",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    showHeader("create-devenv track");
+
+    const targetDir = resolve(args.dir);
+
+    // modules.jsonc の存在確認
+    if (!modulesFileExists(targetDir)) {
+      log.error(".devenv/modules.jsonc not found.");
+      log.dim("Run 'create-devenv init' first to set up the project.");
+      process.exit(1);
+    }
+
+    // --list モード: 現在の追跡パターンを表示
+    if (args.list) {
+      const { modules } = await loadModulesFile(targetDir);
+      log.newline();
+      log.info(pc.bold("Tracked modules and patterns:"));
+      log.newline();
+      for (const mod of modules) {
+        console.log(`  ${pc.cyan(mod.id)} ${pc.dim(`(${mod.name})`)}`);
+        if (mod.description) {
+          console.log(`    ${pc.dim(mod.description)}`);
+        }
+        for (const pattern of mod.patterns) {
+          console.log(`    ${pc.dim("→")} ${pattern}`);
+        }
+        log.newline();
+      }
+      return;
+    }
+
+    // パターン引数のパース（citty は positional を単一の文字列として渡す）
+    // process.argv から track 以降の positional 引数を収集
+    const rawArgs = process.argv.slice(2);
+    const trackIdx = rawArgs.indexOf("track");
+    const argsAfterTrack = trackIdx !== -1 ? rawArgs.slice(trackIdx + 1) : rawArgs;
+
+    // フラグ以外の引数をパターンとして収集
+    const patterns: string[] = [];
+    let i = 0;
+    while (i < argsAfterTrack.length) {
+      const arg = argsAfterTrack[i];
+      if (arg === "--list" || arg === "-l" || arg === "--help" || arg === "-h") {
+        i++;
+        continue;
+      }
+      // 値付きフラグをスキップ
+      if (
+        arg === "--dir" ||
+        arg === "-d" ||
+        arg === "--module" ||
+        arg === "-m" ||
+        arg === "--name" ||
+        arg === "--description"
+      ) {
+        i += 2; // フラグ + 値
+        continue;
+      }
+      // フラグ以外の引数はパターン
+      if (!arg.startsWith("-")) {
+        patterns.push(arg);
+      }
+      i++;
+    }
+
+    if (patterns.length === 0) {
+      log.error("No patterns specified.");
+      log.dim("Usage: create-devenv track <patterns...> [--module <id>]");
+      log.dim("Example: create-devenv track '.cloud/rules/*.md' '.cloud/config.json'");
+      process.exit(1);
+    }
+
+    // モジュール ID の決定
+    const moduleId = args.module || inferModuleId(patterns[0]);
+
+    // modules.jsonc を読み込み
+    const { rawContent } = await loadModulesFile(targetDir);
+
+    // パターンを追加（モジュールがなければ作成）
+    const updatedContent = addPatternToModulesFileWithCreate(rawContent, moduleId, patterns, {
+      name: args.name,
+      description: args.description,
+    });
+
+    if (updatedContent === rawContent) {
+      log.newline();
+      log.info("All patterns are already tracked. No changes needed.");
+      return;
+    }
+
+    // 保存
+    await saveModulesFile(targetDir, updatedContent);
+
+    // 結果表示
+    log.newline();
+    box("Patterns added!", "success");
+    log.newline();
+
+    console.log(`  ${pc.bold("Module:")} ${pc.cyan(moduleId)}`);
+    console.log(`  ${pc.bold("Added:")}`);
+    for (const pattern of patterns) {
+      console.log(`    ${pc.green("+")} ${pattern}`);
+    }
+    log.newline();
+    log.dim(`Updated .devenv/modules.jsonc`);
+    log.newline();
+  },
+});

--- a/packages/create-devenv/src/docs/ai-guide.ts
+++ b/packages/create-devenv/src/docs/ai-guide.ts
@@ -188,6 +188,43 @@ npx @tktco/create-devenv track --list
 5. **Use environment variables** for tokens instead of hardcoding in manifest
 6. **Use \`track\` command** to add new files to the sync whitelist before pushing`,
     },
+    {
+      title: "Track + Push: Adding New Files to Template",
+      content: `When you create new files that should be part of the template, use \`track\` then \`push\`.
+The \`push\` command **automatically detects** changes made by \`track\` to the local \`modules.jsonc\`
+and includes them in the PR.
+
+### Workflow
+
+\`\`\`bash
+# 1. Create files locally
+mkdir -p .cloud/rules
+echo "naming conventions..." > .cloud/rules/naming.md
+
+# 2. Add to tracking (updates local .devenv/modules.jsonc)
+npx @tktco/create-devenv track ".cloud/rules/*.md"
+
+# 3. Push detects local module additions automatically
+npx @tktco/create-devenv push --prepare
+\`\`\`
+
+### What happens internally
+
+1. \`track\` adds patterns to **local** \`.devenv/modules.jsonc\` (creates new modules if needed)
+2. \`push --prepare\` downloads the template and compares its \`modules.jsonc\` with local
+3. New modules and patterns are detected and merged into the detection scope
+4. The manifest includes:
+   - New files (\`.cloud/rules/naming.md\`) as \`type: added\` with \`selected: true\`
+   - \`.devenv/modules.jsonc\` as \`type: modified\` with \`selected: true\`
+5. \`push --execute\` creates a PR that adds both the files AND the updated module definitions
+
+### Key behavior
+
+- **No need to manually edit modules.jsonc** — \`track\` handles it
+- **push detects local changes** — no extra flags needed; just run \`push --prepare\` after \`track\`
+- **New modules are auto-created** — if \`.cloud\` doesn't exist in the template, it's added
+- **Existing module patterns can also be extended** — \`track\` works for both new and existing modules`,
+    },
   ];
 }
 

--- a/packages/create-devenv/src/docs/ai-guide.ts
+++ b/packages/create-devenv/src/docs/ai-guide.ts
@@ -49,6 +49,11 @@ npx @tktco/create-devenv push --prepare    # Generate manifest
 # Edit ${MANIFEST_FILENAME}              # Select files
 npx @tktco/create-devenv push --execute    # Create PR
 
+# Add files to tracking (non-interactive)
+npx @tktco/create-devenv track ".cloud/rules/*.md"            # Add pattern (auto-detect module)
+npx @tktco/create-devenv track ".cloud/config.json" -m .cloud # Specify module explicitly
+npx @tktco/create-devenv track --list                         # List tracked modules/patterns
+
 # Other commands
 npx @tktco/create-devenv init [dir]        # Apply template (interactive)
 npx @tktco/create-devenv diff              # Show differences
@@ -129,12 +134,59 @@ npx @tktco/create-devenv push --execute
 The token needs \`repo\` scope for creating PRs.`,
     },
     {
+      title: "Track Command for AI Agents",
+      content: `The \`track\` command allows AI agents to add files or patterns to the sync whitelist non-interactively.
+This is useful when you create new files or directories that should be part of the template.
+
+### Add patterns to an existing module
+
+\`\`\`bash
+# Auto-detects module from path (.claude module)
+npx @tktco/create-devenv track ".claude/commands/*.md"
+
+# Explicit module
+npx @tktco/create-devenv track ".devcontainer/new-script.sh" --module .devcontainer
+\`\`\`
+
+### Create a new module with patterns
+
+When the module doesn't exist yet, it is automatically created:
+
+\`\`\`bash
+# Creates ".cloud" module and adds the pattern
+npx @tktco/create-devenv track ".cloud/rules/*.md"
+
+# With custom name and description
+npx @tktco/create-devenv track ".cloud/rules/*.md" \\
+  --module .cloud \\
+  --name "Cloud Rules" \\
+  --description "Cloud configuration and rule files"
+\`\`\`
+
+### List current tracking configuration
+
+\`\`\`bash
+npx @tktco/create-devenv track --list
+\`\`\`
+
+### Options
+
+| Option | Alias | Description |
+|--------|-------|-------------|
+| \`--module <id>\` | \`-m\` | Module ID to add patterns to (auto-detected if omitted) |
+| \`--name <name>\` | | Module display name (for new modules) |
+| \`--description <desc>\` | | Module description (for new modules) |
+| \`--dir <path>\` | \`-d\` | Project directory (default: current directory) |
+| \`--list\` | \`-l\` | List all tracked modules and patterns |`,
+    },
+    {
       title: "Best Practices for AI Agents",
       content: `1. **Always use \`--prepare\` then \`--execute\`** for non-interactive operation
 2. **Review the diff first** with \`npx @tktco/create-devenv diff\`
 3. **Set meaningful PR titles** that follow conventional commits (e.g., \`feat:\`, \`fix:\`, \`docs:\`)
 4. **Deselect unrelated changes** by setting \`selected: false\`
-5. **Use environment variables** for tokens instead of hardcoding in manifest`,
+5. **Use environment variables** for tokens instead of hardcoding in manifest
+6. **Use \`track\` command** to add new files to the sync whitelist before pushing`,
     },
   ];
 }

--- a/packages/create-devenv/src/index.ts
+++ b/packages/create-devenv/src/index.ts
@@ -6,6 +6,7 @@ import { aiDocsCommand } from "./commands/ai-docs";
 import { diffCommand } from "./commands/diff";
 import { initCommand } from "./commands/init";
 import { pushCommand } from "./commands/push";
+import { trackCommand } from "./commands/track";
 import { log, pc, showHeader } from "./utils/ui";
 
 const main = defineCommand({
@@ -18,6 +19,7 @@ const main = defineCommand({
     init: initCommand,
     push: pushCommand,
     diff: diffCommand,
+    track: trackCommand,
     "ai-docs": aiDocsCommand,
   },
 });
@@ -79,7 +81,7 @@ async function promptCommand(): Promise<void> {
 const args = process.argv.slice(2);
 const hasSubCommand =
   args.length > 0 &&
-  ["init", "push", "diff", "ai-docs", "--help", "-h", "--version", "-v"].includes(args[0]);
+  ["init", "push", "diff", "track", "ai-docs", "--help", "-h", "--version", "-v"].includes(args[0]);
 
 if (!hasSubCommand && args.length > 0 && !args[0].startsWith("-")) {
   // npx @tktco/create-devenv . のような形式は init コマンドとして実行

--- a/packages/create-devenv/src/modules/index.ts
+++ b/packages/create-devenv/src/modules/index.ts
@@ -3,6 +3,7 @@ import type { TemplateModule } from "./schemas";
 // Re-export loader functions
 export {
   addPatternToModulesFile,
+  addPatternToModulesFileWithCreate,
   getModulesFilePath,
   loadModulesFile,
   modulesFileExists,


### PR DESCRIPTION
## Summary

This PR introduces a new `track` command that allows AI agents and users to non-interactively add file patterns to the `.devenv/modules.jsonc` whitelist. It also enhances the `push` command to automatically detect and merge local module additions made by `track`.

## Key Changes

### New `track` Command
- **New file**: `packages/create-devenv/src/commands/track.ts`
  - Adds patterns to existing modules or creates new modules automatically
  - Auto-detects module ID from file paths (e.g., `.cloud/rules/*.md` → `.cloud` module)
  - Supports explicit module specification via `--module` flag
  - Allows custom module names and descriptions for new modules
  - Includes `--list` option to display current tracking configuration
  - Comprehensive test coverage in `track.test.ts`

### Enhanced Module Management
- **New function**: `addPatternToModulesFileWithCreate()` in `modules/loader.ts`
  - Extends existing `addPatternToModulesFile()` to create modules if they don't exist
  - Auto-generates sensible default names and descriptions for new modules
  - Includes full test coverage

### Improved `push` Command Integration
- **New function**: `detectLocalModuleAdditions()` in `push.ts`
  - Compares local `modules.jsonc` with template version
  - Detects new modules added by `track` command
  - Detects pattern additions to existing modules
  - Merges local changes into the detection scope
  
- **Enhanced workflow**:
  - Automatically includes detected local module changes in PR manifest
  - Works in both interactive and `--prepare`/`--execute` modes
  - Properly handles both new modules and pattern additions to existing modules
  - Includes `modules.jsonc` in the PR when changes are detected

### Documentation
- **Updated**: `ai-guide.ts` with comprehensive documentation
  - Usage examples for `track` command
  - Workflow guide for "Track + Push" pattern
  - Explanation of automatic detection behavior
  - Best practices for AI agents

## Implementation Details

- **Module ID inference**: Extracts the first path component from patterns (e.g., `.cloud/rules/*.md` → `.cloud`)
- **Default naming**: Converts module IDs to title case (`.cloud` → `Cloud`, `.` → `Root`)
- **Automatic module creation**: New modules are created with sensible defaults if not explicitly provided
- **Manifest integration**: Local module changes are automatically included in the push manifest with proper file type detection
- **Backward compatibility**: Existing `push` behavior is preserved; new functionality is additive

## Testing

- Comprehensive unit tests for `addPatternToModulesFileWithCreate()`
- Tests for module creation, pattern addition, and default naming
- Tests for file I/O operations with memfs

https://claude.ai/code/session_012pRbYvbFy1AXECwWe3ea7U