### PR TITLE
feat: add Jujutsu (jj) VCS support to devenv template

### DIFF
--- a/.claude/hooks/ensure-jj.sh
+++ b/.claude/hooks/ensure-jj.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Hook: セッション開始時に jj がインストールされていることを確認する
+# SessionStart hook
+
+set -euo pipefail
+
+# 1. PATH に jj があればOK
+if command -v jj &>/dev/null; then
+  exit 0
+fi
+
+# 2. mise 経由でインストールを試みる
+if command -v mise &>/dev/null; then
+  echo "jj が見つかりません。mise 経由でインストールします..."
+  if mise install jj 2>/dev/null; then
+    eval "$(mise activate bash 2>/dev/null)" || true
+    if command -v jj &>/dev/null; then
+      echo "jj $(jj --version) をインストールしました"
+      exit 0
+    fi
+  fi
+fi
+
+# 3. GitHub リリースからダウンロード
+echo "mise でのインストールに失敗しました。GitHub から直接ダウンロードします..."
+
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "${OS}-${ARCH}" in
+  linux-x86_64)  TARGET="x86_64-unknown-linux-musl" ;;
+  linux-aarch64) TARGET="aarch64-unknown-linux-musl" ;;
+  darwin-x86_64) TARGET="x86_64-apple-darwin" ;;
+  darwin-arm64)  TARGET="aarch64-apple-darwin" ;;
+  *)
+    echo "警告: サポートされていないプラットフォーム (${OS}-${ARCH})"
+    echo "手動でインストールしてください: https://jj-vcs.github.io/jj/latest/install-and-setup/"
+    exit 0
+    ;;
+esac
+
+LATEST_TAG=$(curl -fsSL "https://api.github.com/repos/jj-vcs/jj/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+
+if [ -z "$LATEST_TAG" ]; then
+  echo "警告: 最新バージョンの取得に失敗しました"
+  echo "手動でインストールしてください: https://jj-vcs.github.io/jj/latest/install-and-setup/"
+  exit 0
+fi
+
+DOWNLOAD_URL="https://github.com/jj-vcs/jj/releases/download/${LATEST_TAG}/jj-${LATEST_TAG}-${TARGET}.tar.gz"
+INSTALL_DIR="${HOME}/bin"
+
+mkdir -p "$INSTALL_DIR"
+
+if curl -fsSL "$DOWNLOAD_URL" | tar xz -C "$INSTALL_DIR" jj 2>/dev/null; then
+  chmod +x "${INSTALL_DIR}/jj"
+  export PATH="${INSTALL_DIR}:${PATH}"
+  echo "jj ${LATEST_TAG} を ${INSTALL_DIR} にインストールしました"
+else
+  echo "警告: jj のダウンロードに失敗しました"
+  echo "手動でインストールしてください: https://jj-vcs.github.io/jj/latest/install-and-setup/"
+fi
+
+exit 0

--- a/.claude/hooks/prefer-jj.sh
+++ b/.claude/hooks/prefer-jj.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Hook: git commit/add を検出して jj の使用を促す
+# PreToolUse hook for Bash tool
+
+set -euo pipefail
+
+# stdin から JSON を読み取る
+input=$(cat)
+
+# tool_input.command を抽出
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+if [ -z "$command" ]; then
+  exit 0
+fi
+
+# git commit を検出
+if echo "$command" | grep -qE '^\s*git\s+commit'; then
+  cat <<'EOF'
+╭──────────────────────────────────────────────╮
+│  git commit の代わりに jj を使ってください    │
+│                                              │
+│  jj commit -m "message"                      │
+│  jj describe -m "message"                    │
+│                                              │
+│  参考: CLAUDE.md, .claude/rules/jujutsu.md   │
+╰──────────────────────────────────────────────╯
+EOF
+  exit 2
+fi
+
+# git add を検出
+if echo "$command" | grep -qE '^\s*git\s+add'; then
+  cat <<'EOF'
+╭──────────────────────────────────────────────╮
+│  git add は不要です                           │
+│                                              │
+│  jj は変更を自動的に追跡します               │
+│  直接 jj commit -m "message" を使ってください │
+│                                              │
+│  参考: CLAUDE.md, .claude/rules/jujutsu.md   │
+╰──────────────────────────────────────────────╯
+EOF
+  exit 2
+fi
+
+exit 0

--- a/.claude/rules/jujutsu.md
+++ b/.claude/rules/jujutsu.md
@@ -1,0 +1,27 @@
+# Jujutsu (jj) VCS ルール
+
+このプロジェクトでは Git の代わりに jj (Jujutsu) を使用する。
+
+## 基本ルール
+- `git add` は使わない（jj は変更を自動追跡する）
+- `git commit` は使わない（代わりに `jj commit` を使う）
+- `git status` の代わりに `jj status` を使う
+- `git log` の代わりに `jj log` を使う
+- `git diff` の代わりに `jj diff` を使う
+
+## よく使うコマンド
+```bash
+jj status           # 現在の変更状態を確認
+jj log              # コミット履歴を表示
+jj diff             # 変更差分を表示
+jj commit -m "msg"  # 変更をコミット
+jj describe -m "msg" # 現在の変更にメッセージを設定
+jj new              # 新しい空のチェンジを作成
+jj bookmark create <name>  # ブックマーク（≒ブランチ）を作成
+jj git push         # リモートにプッシュ
+```
+
+## Git との共存
+- jj は Git リポジトリと colocated モードで動作している
+- `.jj/` ディレクトリは `.gitignore` に含めないこと（jj が管理する）
+- `jj git push` で GitHub にプッシュできる

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,30 @@
 {
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/ensure-jj.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/prefer-jj.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
   "permissions": {
     "allow": [],
     "deny": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -55,7 +55,7 @@
     "install-packages": [
       "bash",
       "-c",
-      "set -e; sudo apt-get update && sudo apt-get install -y build-essential fzf ripgrep bc gpg ca-certificates curl"
+      "set -e; sudo apt-get update && sudo apt-get install -y build-essential fzf ripgrep bc gpg ca-certificates curl tmux"
     ]
   },
   "updateContentCommand": {
@@ -68,7 +68,8 @@
     "trust-mise": ["mise", "trust"]
   },
   "postCreateCommand": {
-    "mise-install": "mise install"
+    "mise-install": "mise install",
+    "fix-pnpm-store-permissions": ["bash", "-lc", "sudo chown -R $(whoami) .pnpm-store"]
   },
   "postStartCommand": {
     "setup-chrome-devtools-mcp": ["bash", "-lc", ".devcontainer/setup-chrome-devtools-mcp.sh"],

--- a/.mise.toml
+++ b/.mise.toml
@@ -3,6 +3,7 @@ node = ["22", "24"]
 uv = "latest"
 python = "3.14"
 pnpm = "10"
+jj = "latest"
 
 "npm:@anthropic-ai/claude-code" = "latest"
 "npm:@openai/codex" = "latest"


### PR DESCRIPTION
## Summary

Auto-generated PR by create-devenv push command.

## Changed files

- `.claude/hooks/ensure-jj.sh`
- `.claude/hooks/prefer-jj.sh`
- `.claude/rules/jujutsu.md`
- `.claude/settings.json`
- `.devcontainer/devcontainer.json`
- `.mise.toml`

---
Generated by [@tktco/create-devenv](https://github.com/tktcorporation/.github/tree/main/packages/create-devenv)
