### PR TITLE
Copy modules.jsonc from template during init command

### DIFF
--- a/.changeset/fix-track-init-modules-jsonc.md
+++ b/.changeset/fix-track-init-modules-jsonc.md
@@ -1,0 +1,5 @@
+---
+"@tktco/create-devenv": patch
+---
+
+init コマンドでテンプレートの .devenv/modules.jsonc をターゲットプロジェクトにコピーするように修正。これにより init → track のワークフローが正しく動作するようになります。


### PR DESCRIPTION
## Summary
This PR adds functionality to copy the `modules.jsonc` file from the template to the target project during the `init` command execution. This ensures the `init → track` workflow functions correctly by providing the necessary modules configuration file.

## Key Changes
- Added `copyFile` mock to the init command test suite
- Imported `copyFile` utility function and `getModulesFilePath` module helper
- Implemented `copyModulesJsonc()` function that:
  - Copies `.devenv/modules.jsonc` from the template directory to the target project
  - Respects the user's overwrite strategy (prompt/force/skip)
  - Gracefully skips if the source file doesn't exist
- Integrated the modules.jsonc copy operation into the init command workflow
- Added comprehensive test case to verify the copy operation is called with correct parameters

## Implementation Details
- The `copyModulesJsonc()` function is called after environment file creation but before the config file generation
- Uses the same `OverwriteStrategy` as other file operations for consistency
- Returns a `FileOperationResult` to track the operation outcome (copied/skipped)
- The operation is included in the summary results displayed to the user

https://claude.ai/code/session_01SL8htngAikJw9dJBUS4oQA