### PR TITLE
feat(init): add --modules and --overwrite-strategy options

### DIFF
--- a/.changeset/init-non-interactive-options.md
+++ b/.changeset/init-non-interactive-options.md
@@ -1,0 +1,5 @@
+---
+"@tktco/create-devenv": minor
+---
+
+init コマンドに --modules (-m) と --overwrite-strategy (-s) オプションを追加し、AI エージェントが非インタラクティブにモジュール選択と上書き戦略を指定可能に

--- a/.claude/rules/jujutsu.md
+++ b/.claude/rules/jujutsu.md
@@ -3,6 +3,7 @@
 このプロジェクトでは Git の代わりに jj (Jujutsu) を使用する。
 
 ## 基本ルール
+
 - `git add` は使わない（jj は変更を自動追跡する）
 - `git commit` は使わない（代わりに `jj commit` を使う）
 - `git status` の代わりに `jj status` を使う
@@ -10,6 +11,7 @@
 - `git diff` の代わりに `jj diff` を使う
 
 ## よく使うコマンド
+
 ```bash
 jj status           # 現在の変更状態を確認
 jj log              # コミット履歴を表示
@@ -22,6 +24,7 @@ jj git push         # リモートにプッシュ
 ```
 
 ## Git との共存
+
 - jj は Git リポジトリと colocated モードで動作している
 - `.jj/` ディレクトリは `.gitignore` に含めないこと（jj が管理する）
 - `jj git push` で GitHub にプッシュできる

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,11 +37,7 @@
     ]
   },
   "enableAllProjectMcpServers": true,
-  "enabledMcpjsonServers": [
-    "chrome-devtools",
-    "ide",
-    "context7"
-  ],
+  "enabledMcpjsonServers": ["chrome-devtools", "ide", "context7"],
   "enabledPlugins": {
     "document-skills@anthropic-agent-skills": true,
     "example-skills@anthropic-agent-skills": true,

--- a/packages/create-devenv/CHANGELOG.md
+++ b/packages/create-devenv/CHANGELOG.md
@@ -7,7 +7,6 @@
 - [#74](https://github.com/tktcorporation/.github/pull/74) [`64b3475`](https://github.com/tktcorporation/.github/commit/64b3475c39362cadc4a332fa3eeb91c7f5d8c12f) Thanks [@tktcorporation](https://github.com/tktcorporation)! - feat: add `track` command for non-interactive file tracking management
 
   AI エージェントが非インタラクティブにファイルパターンを `.devenv/modules.jsonc` のホワイトリストに追加できる `track` コマンドを追加。
-
   - `npx @tktco/create-devenv track ".cloud/rules/*.md"` でパターン追加（モジュール自動検出）
   - `--module` オプションで明示的にモジュール指定可能
   - 存在しないモジュールは自動作成（`--name`, `--description` でカスタマイズ可能）
@@ -43,7 +42,6 @@
 ### Minor Changes
 
 - [#61](https://github.com/tktcorporation/.github/pull/61) [`41ea99b`](https://github.com/tktcorporation/.github/commit/41ea99b9c0ed8f9fbe88c976735577cece92636c) Thanks [@tktcorporation](https://github.com/tktcorporation)! - Add AI-agent friendly manifest-based push workflow
-
   - `--prepare` option: Generates a YAML manifest file (`.devenv-push-manifest.yaml`) for reviewing and editing file selections
   - `--execute` option: Creates a PR based on the manifest file without interactive prompts
 
@@ -54,7 +52,6 @@
 ### Patch Changes
 
 - [#51](https://github.com/tktcorporation/.github/pull/51) [`71d6e04`](https://github.com/tktcorporation/.github/commit/71d6e04edd297f79e56d1a6df40262da2e22d2a4) Thanks [@tktcorporation](https://github.com/tktcorporation)! - feat(init): gitignore 対象ファイルの同期時の挙動を改善
-
   - init 時に gitignore 対象のファイルがローカルに既存在する場合、上書きせずスキップして警告を表示
   - gitignore 対象のファイルがローカルに存在しない場合は、通常通りコピー
   - push 時は gitignore 対象ファイルを追跡対象から除外（既存の動作を維持）
@@ -71,7 +68,6 @@
 ### Minor Changes
 
 - [#45](https://github.com/tktcorporation/.github/pull/45) [`4557ba0`](https://github.com/tktcorporation/.github/commit/4557ba09b019d2f8f0dbaad3f274d6c4e56c9731) Thanks [@tktcorporation](https://github.com/tktcorporation)! - feat(create-devenv): improve diff display with summary box and interactive viewer
-
   - Add new diff-viewer.ts with modern box-styled summary display
   - Show file changes grouped by type (added/modified/deleted) with line stats
   - Add interactive diff viewer with n/p navigation between files
@@ -85,7 +81,6 @@
 ### Patch Changes
 
 - [#47](https://github.com/tktcorporation/.github/pull/47) [`052075d`](https://github.com/tktcorporation/.github/commit/052075dd830d4ccc8eae4b949a73db164e903df7) Thanks [@tktcorporation](https://github.com/tktcorporation)! - テストを大幅に拡充
-
   - config.ts: 設定ファイルの読み書きテスト
   - patterns.ts: パターンマッチングとマージのテスト
   - modules/schemas.ts: Zod スキーマバリデーションテスト
@@ -146,20 +141,17 @@
 - [#23](https://github.com/tktcorporation/.github/pull/23) [`ec36c47`](https://github.com/tktcorporation/.github/commit/ec36c474aac4e01b30ad018507f5fe7f9a305da2) Thanks [@tktcorporation](https://github.com/tktcorporation)! - push コマンドにホワイトリスト外ファイル検知機能を追加し、モジュール定義を外部化
 
   ### ホワイトリスト外ファイル検知
-
   - push 時にホワイトリスト（patterns）に含まれていないファイルを検出
   - モジュールごとにグループ化して選択 UI を表示
   - 選択したファイルを modules.jsonc に自動追加（PR に含まれる）
   - gitignore されているファイルは自動で除外
 
   ### モジュール定義の外部化
-
   - モジュール定義をコードから `.devenv/modules.jsonc` に外部化
   - テンプレートリポジトリの modules.jsonc から動的に読み込み
   - `customPatterns` を廃止し modules.jsonc に統合
 
   ### ディレクトリベースのモジュール設計
-
   - モジュール ID をディレクトリパスベースに変更（例: `.devcontainer`, `.github`, `.`）
   - ファイルパスから即座にモジュール ID を導出可能に
   - モジュール間のファイル重複を構造的に防止
@@ -169,7 +161,6 @@
 ### Minor Changes
 
 - [#14](https://github.com/tktcorporation/.github/pull/14) [`c026ed5`](https://github.com/tktcorporation/.github/commit/c026ed55da57df6599f7c57cdbb5d29c05e3273d) Thanks [@tktcorporation](https://github.com/tktcorporation)! - .gitignore に記載されたファイルを自動的に除外する機能を追加
-
   - init, diff, push の全コマンドで .gitignore にマッチするファイルを除外
   - ローカルディレクトリとテンプレートリポジトリ両方の .gitignore をチェック
   - クレデンシャル等の機密情報の誤流出を防止
@@ -186,12 +177,10 @@
 - [#12](https://github.com/tktcorporation/.github/pull/12) [`798d3fb`](https://github.com/tktcorporation/.github/commit/798d3fb332bdffbc4feac24d9ed89a1b510d7fcf) Thanks [@tktcorporation](https://github.com/tktcorporation)! - 双方向同期機能とホワイトリスト形式を追加
 
   ### 新機能
-
   - `push` コマンド: ローカル変更を GitHub PR として自動送信
   - `diff` コマンド: ローカルとテンプレートの差分をプレビュー
 
   ### 破壊的変更
-
   - モジュール定義を `files` + `excludeFiles` 形式から `patterns` (glob) 形式に移行
   - テンプレート対象ファイルをホワイトリスト形式で明示的に指定するように変更
 
@@ -227,7 +216,6 @@
 ### Patch Changes
 
 - [#4](https://github.com/tktcorporation/.github/pull/4) [`ae7c5e7`](https://github.com/tktcorporation/.github/commit/ae7c5e712b1a16963cd0cd920a92dd589f5e9f84) Thanks [@tktcorporation](https://github.com/tktcorporation)! - fix: overwriteStrategy オプションが正しく機能するように修正
-
   - "prompt" 戦略: ファイルごとにユーザーに上書き確認を表示
   - "skip" 戦略: 既存ファイルをスキップして新規ファイルのみコピー
   - "overwrite" 戦略: 既存ファイルを全て上書き

--- a/packages/create-devenv/src/commands/__tests__/init.test.ts
+++ b/packages/create-devenv/src/commands/__tests__/init.test.ts
@@ -273,6 +273,173 @@ describe("initCommand", () => {
       expect(mockCleanup).toHaveBeenCalled();
     });
 
+    it("--modules オプションで指定モジュールのみ選択", async () => {
+      vol.fromJSON({
+        "/test": null,
+      });
+
+      mockFetchTemplates.mockResolvedValue([{ action: "copied", path: ".mcp.json" }]);
+
+      await (initCommand.run as any)({
+        args: { dir: "/test", force: false, yes: false, modules: "." },
+        rawArgs: [],
+        cmd: initCommand,
+      });
+
+      // promptInit は呼ばれない（非インタラクティブ）
+      expect(mockPromptInit).not.toHaveBeenCalled();
+      // fetchTemplates は指定モジュールで呼ばれる
+      expect(mockFetchTemplates).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modules: ["."],
+        }),
+      );
+    });
+
+    it("--modules で複数モジュールをカンマ区切りで指定", async () => {
+      vol.fromJSON({
+        "/test": null,
+      });
+
+      mockFetchTemplates.mockResolvedValue([]);
+
+      await (initCommand.run as any)({
+        args: { dir: "/test", force: false, yes: false, modules: ".,.github" },
+        rawArgs: [],
+        cmd: initCommand,
+      });
+
+      expect(mockPromptInit).not.toHaveBeenCalled();
+      expect(mockFetchTemplates).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modules: [".", ".github"],
+        }),
+      );
+    });
+
+    it("--modules で無効なモジュール ID を指定するとエラー", async () => {
+      vol.fromJSON({
+        "/test": null,
+      });
+
+      await (initCommand.run as any)({
+        args: { dir: "/test", force: false, yes: false, modules: "invalid-module" },
+        rawArgs: [],
+        cmd: initCommand,
+      });
+
+      expect(mockLog.error).toHaveBeenCalledWith(expect.stringContaining("Unknown module(s)"));
+      expect(mockFetchTemplates).not.toHaveBeenCalled();
+    });
+
+    it("--overwrite-strategy で skip 戦略を指定", async () => {
+      vol.fromJSON({
+        "/test": null,
+      });
+
+      mockFetchTemplates.mockResolvedValue([]);
+
+      await (initCommand.run as any)({
+        args: {
+          dir: "/test",
+          force: false,
+          yes: true,
+          "overwrite-strategy": "skip",
+        },
+        rawArgs: [],
+        cmd: initCommand,
+      });
+
+      expect(mockFetchTemplates).toHaveBeenCalledWith(
+        expect.objectContaining({
+          overwriteStrategy: "skip",
+        }),
+      );
+    });
+
+    it("--modules と --overwrite-strategy の組み合わせ", async () => {
+      vol.fromJSON({
+        "/test": null,
+      });
+
+      mockFetchTemplates.mockResolvedValue([]);
+
+      await (initCommand.run as any)({
+        args: {
+          dir: "/test",
+          force: false,
+          yes: false,
+          modules: ".",
+          "overwrite-strategy": "skip",
+        },
+        rawArgs: [],
+        cmd: initCommand,
+      });
+
+      expect(mockPromptInit).not.toHaveBeenCalled();
+      expect(mockFetchTemplates).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modules: ["."],
+          overwriteStrategy: "skip",
+        }),
+      );
+    });
+
+    it("--overwrite-strategy に無効な値を指定するとエラー", async () => {
+      vol.fromJSON({
+        "/test": null,
+      });
+
+      await (initCommand.run as any)({
+        args: {
+          dir: "/test",
+          force: false,
+          yes: true,
+          "overwrite-strategy": "invalid",
+        },
+        rawArgs: [],
+        cmd: initCommand,
+      });
+
+      expect(mockLog.error).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid overwrite strategy"),
+      );
+      expect(mockFetchTemplates).not.toHaveBeenCalled();
+    });
+
+    it("--overwrite-strategy のみ指定時はモジュール選択はインタラクティブ", async () => {
+      vol.fromJSON({
+        "/test": null,
+      });
+
+      mockPromptInit.mockResolvedValueOnce({
+        modules: ["."],
+        overwriteStrategy: "prompt",
+      });
+
+      mockFetchTemplates.mockResolvedValue([]);
+
+      await (initCommand.run as any)({
+        args: {
+          dir: "/test",
+          force: false,
+          yes: false,
+          "overwrite-strategy": "skip",
+        },
+        rawArgs: [],
+        cmd: initCommand,
+      });
+
+      // モジュール選択はインタラクティブ
+      expect(mockPromptInit).toHaveBeenCalled();
+      // 戦略は --overwrite-strategy で上書き
+      expect(mockFetchTemplates).toHaveBeenCalledWith(
+        expect.objectContaining({
+          overwriteStrategy: "skip",
+        }),
+      );
+    });
+
     it("'init' 引数は無視して現在のディレクトリを使用", async () => {
       vol.fromJSON({
         ".": null,

--- a/packages/create-devenv/src/commands/init.ts
+++ b/packages/create-devenv/src/commands/init.ts
@@ -55,6 +55,16 @@ export const initCommand = defineCommand({
       description: "Select all modules (non-interactive mode)",
       default: false,
     },
+    modules: {
+      type: "string",
+      alias: "m",
+      description: "Comma-separated module IDs to apply (non-interactive)",
+    },
+    "overwrite-strategy": {
+      type: "string",
+      alias: "s",
+      description: "Overwrite strategy: overwrite, skip, or prompt (non-interactive)",
+    },
   },
   async run({ args }) {
     // ヘッダー表示
@@ -97,12 +107,55 @@ export const initCommand = defineCommand({
       log.newline();
 
       let answers: Answers;
-      if (args.yes) {
+      const hasModulesArg = typeof args.modules === "string" && args.modules.length > 0;
+      const hasStrategyArg =
+        typeof args["overwrite-strategy"] === "string" && args["overwrite-strategy"].length > 0;
+
+      if (args.yes || hasModulesArg) {
+        // --yes: 全モジュール選択、--modules: 指定モジュール選択
+        let selectedModules: string[];
+        if (hasModulesArg) {
+          const requestedIds = (args.modules as string).split(",").map((s) => s.trim());
+          const validIds = moduleList.map((m) => m.id);
+          const invalidIds = requestedIds.filter((id) => !validIds.includes(id));
+          if (invalidIds.length > 0) {
+            log.error(
+              `Unknown module(s): ${invalidIds.join(", ")}. Available: ${validIds.join(", ")}`,
+            );
+            return;
+          }
+          selectedModules = requestedIds;
+        } else {
+          selectedModules = moduleList.map((m) => m.id);
+        }
+
+        // --overwrite-strategy: 指定戦略、なければ overwrite
+        let overwriteStrategy: OverwriteStrategy = "overwrite";
+        if (hasStrategyArg) {
+          const strategy = args["overwrite-strategy"] as string;
+          if (strategy !== "overwrite" && strategy !== "skip" && strategy !== "prompt") {
+            log.error(
+              `Invalid overwrite strategy: ${strategy}. Must be: overwrite, skip, or prompt`,
+            );
+            return;
+          }
+          overwriteStrategy = strategy;
+        }
+
         answers = {
-          modules: moduleList.map((m) => m.id),
-          overwriteStrategy: "overwrite",
+          modules: selectedModules,
+          overwriteStrategy,
         };
-        log.info(`Auto-selected ${pc.cyan(moduleList.length.toString())} modules`);
+        log.info(`Selected ${pc.cyan(selectedModules.length.toString())} modules`);
+      } else if (hasStrategyArg) {
+        // --overwrite-strategy のみ指定：モジュール選択はインタラクティブ
+        const strategy = args["overwrite-strategy"] as string;
+        if (strategy !== "overwrite" && strategy !== "skip" && strategy !== "prompt") {
+          log.error(`Invalid overwrite strategy: ${strategy}. Must be: overwrite, skip, or prompt`);
+          return;
+        }
+        answers = await promptInit(moduleList);
+        answers.overwriteStrategy = strategy;
       } else {
         answers = await promptInit(moduleList);
       }

--- a/packages/create-devenv/src/docs/ai-guide.ts
+++ b/packages/create-devenv/src/docs/ai-guide.ts
@@ -44,6 +44,12 @@ export function getDocSections(): DocSection[] {
     {
       title: "Quick Reference",
       content: `\`\`\`bash
+# Non-interactive init for AI agents
+npx @tktco/create-devenv init --yes                           # All modules, overwrite strategy
+npx @tktco/create-devenv init --modules .,devcontainer        # Specific modules only
+npx @tktco/create-devenv init --modules .github -s skip       # Specific modules with skip strategy
+npx @tktco/create-devenv init --yes --overwrite-strategy skip # All modules with skip strategy
+
 # Non-interactive push workflow for AI agents
 npx @tktco/create-devenv push --prepare    # Generate manifest
 # Edit ${MANIFEST_FILENAME}              # Select files
@@ -61,6 +67,42 @@ npx @tktco/create-devenv diff              # Show differences (also reports untr
 npx @tktco/create-devenv init [dir]        # Apply template (interactive)
 npx @tktco/create-devenv ai-docs           # Show this guide
 \`\`\``,
+    },
+    {
+      title: "Init Command for AI Agents",
+      content: `The \`init\` command supports non-interactive options for AI agents:
+
+### Options
+
+| Option | Alias | Description |
+|--------|-------|-------------|
+| \`--yes\` | \`-y\` | Select all modules with overwrite strategy |
+| \`--modules <ids>\` | \`-m\` | Comma-separated module IDs to apply |
+| \`--overwrite-strategy <strategy>\` | \`-s\` | Strategy for existing files: \`overwrite\`, \`skip\`, or \`prompt\` |
+| \`--force\` | | Force overwrite (overrides strategy to \`overwrite\`) |
+
+### Examples
+
+\`\`\`bash
+# Apply only specific modules (skips module selection prompt)
+npx @tktco/create-devenv init --modules .github,.claude
+
+# Apply specific modules and skip existing files
+npx @tktco/create-devenv init --modules devcontainer -s skip
+
+# Apply all modules but skip existing files
+npx @tktco/create-devenv init --yes --overwrite-strategy skip
+
+# Re-init when .devenv.json exists, replacing only specific modules
+npx @tktco/create-devenv init --modules . -s overwrite
+\`\`\`
+
+### Behavior
+
+- \`--modules\` or \`--yes\`: Skips the module selection prompt entirely
+- \`--overwrite-strategy\`: Sets how to handle existing files (default: \`overwrite\` in non-interactive mode)
+- When neither is provided, interactive prompts are shown
+- \`.devenv.json\` is always updated regardless of strategy`,
     },
     {
       title: "Important: Untracked Files and the Track Command",
@@ -208,13 +250,14 @@ npx @tktco/create-devenv track --list
     },
     {
       title: "Best Practices for AI Agents",
-      content: `1. **Always use \`--prepare\` then \`--execute\`** for non-interactive operation
-2. **Review the diff first** with \`npx @tktco/create-devenv diff\` — this also reports untracked files
-3. **Check for untracked files** — if \`diff\` or \`push --prepare\` reports untracked files, use \`track\` to add them before pushing
-4. **Use \`track\` command** to add new files to the sync whitelist (non-interactive, no prompts)
-5. **Set meaningful PR titles** that follow conventional commits (e.g., \`feat:\`, \`fix:\`, \`docs:\`)
-6. **Deselect unrelated changes** by setting \`selected: false\`
-7. **Use environment variables** for tokens instead of hardcoding in manifest`,
+      content: `1. **Use \`--modules\` and \`--overwrite-strategy\`** for granular non-interactive init (e.g., \`init --modules .github,.claude -s skip\`)
+2. **Always use \`--prepare\` then \`--execute\`** for non-interactive push operation
+3. **Review the diff first** with \`npx @tktco/create-devenv diff\` — this also reports untracked files
+4. **Check for untracked files** — if \`diff\` or \`push --prepare\` reports untracked files, use \`track\` to add them before pushing
+5. **Use \`track\` command** to add new files to the sync whitelist (non-interactive, no prompts)
+6. **Set meaningful PR titles** that follow conventional commits (e.g., \`feat:\`, \`fix:\`, \`docs:\`)
+7. **Deselect unrelated changes** by setting \`selected: false\`
+8. **Use environment variables** for tokens instead of hardcoding in manifest`,
     },
     {
       title: "Track + Push: Adding New Files to Template",


### PR DESCRIPTION
## Summary

Add non-interactive options to the `init` command to allow AI agents to specify module selection and file overwrite strategy without prompts.

## Key Changes

- **New `--modules` (`-m`) option**: Accept comma-separated module IDs to apply specific modules non-interactively
  - Validates module IDs against available modules
  - Returns error if invalid module IDs are provided
  - Skips the module selection prompt entirely when specified

- **New `--overwrite-strategy` (`-s`) option**: Set how to handle existing files (`overwrite`, `skip`, or `prompt`)
  - Validates strategy values
  - Returns error if invalid strategy is provided
  - When used alone, still prompts for module selection interactively
  - When combined with `--modules` or `--yes`, applies the strategy non-interactively

- **Behavior refinements**:
  - `--yes` and `--modules` are mutually exclusive (both skip module selection prompt)
  - `--overwrite-strategy` can be combined with either `--yes` or `--modules`
  - Default overwrite strategy in non-interactive mode is `overwrite`
  - Updated log message from "Auto-selected" to "Selected" for clarity

- **Documentation updates**:
  - Added AI guide section with examples of non-interactive init usage
  - Updated best practices to recommend granular `--modules` and `--overwrite-strategy` usage
  - Added comprehensive option reference table

- **Test coverage**: Added 7 new test cases covering:
  - Single module selection
  - Multiple comma-separated modules
  - Invalid module ID error handling
  - Overwrite strategy validation
  - Combined `--modules` and `--overwrite-strategy` usage
  - Invalid strategy error handling
  - Interactive module selection with strategy-only flag

## Implementation Details

The logic flow prioritizes non-interactive options:
1. If `--modules` or `--yes` is provided, skip module selection prompt
2. If `--overwrite-strategy` is provided, validate and apply it
3. If only `--overwrite-strategy` is provided without modules, prompt for modules interactively
4. Otherwise, use full interactive flow

This enables AI agents to perform granular template initialization with commands like:
```bash
npx @tktco/create-devenv init --modules .github,.claude -s skip
```

https://claude.ai/code/session_01MgLjaqjuYQsrjnWVxqkDUL