### PR TITLE
Fix untracked files not included in push --execute

### DIFF
--- a/.changeset/light-lines-sip.md
+++ b/.changeset/light-lines-sip.md
@@ -1,0 +1,5 @@
+---
+"@tktco/create-devenv": patch
+---
+
+fix: Claude モジュールの patterns に hooks と rules を追加

--- a/.changeset/vast-windows-lay.md
+++ b/.changeset/vast-windows-lay.md
@@ -1,0 +1,5 @@
+---
+"@tktco/create-devenv": patch
+---
+
+fix: push --execute で未追跡ファイルの内容が PR に含まれないバグを修正

--- a/.devenv/modules.jsonc
+++ b/.devenv/modules.jsonc
@@ -43,6 +43,8 @@
       "setupDescription": "Claude Code project settings will be applied",
       "patterns": [
         ".claude/settings.json",
+        ".claude/hooks/*.sh",
+        ".claude/rules/*.md",
         // Excluded: settings.local.json (personal settings)
       ],
     },


### PR DESCRIPTION
## Summary
This PR fixes a bug in the `push --execute` command where untracked files selected by the user were not being included in the generated pull request. The fix refactors the modules.jsonc processing logic to handle untracked file patterns earlier in the execution flow.

## Key Changes
- **Refactored modules.jsonc processing**: Moved the logic for adding untracked file patterns to the modules list earlier in the execution flow (before `detectDiff`), ensuring that untracked files are properly recognized as pushable files
- **Unified file selection**: Updated the file selection logic to include both manifest files and untracked files when filtering pushable files for the PR
- **Simplified modules.jsonc update logic**: Consolidated the modules.jsonc change handling by computing `updatedModulesContent` once at the beginning and reusing it, eliminating duplicate `detectLocalModuleAdditions` calls
- **Enhanced Claude module patterns**: Added `.claude/hooks/*.sh` and `.claude/rules/*.md` to the Claude module's file patterns to support additional configuration files

## Implementation Details
- The `updatedModulesContent` variable is now computed early and reused throughout the function, ensuring consistency
- Untracked file patterns are added to the modules list before `detectDiff` is called, matching the behavior of interactive mode
- The modules.jsonc file is only added to the PR if there are actual changes (`updatedModulesContent` is defined) and either the file was explicitly selected or untracked files were selected

https://claude.ai/code/session_01RdgqyoLt1L532s4ojnP9P9