### PR TITLE
Document Claude Code hooks and rules directories

### DIFF
--- a/packages/create-devenv/README.md
+++ b/packages/create-devenv/README.md
@@ -188,6 +188,8 @@ GitHub Actions and labeler workflows
 Claude Code project settings
 
 - `.claude/settings.json`
+- `.claude/hooks/*.sh`
+- `.claude/rules/*.md`
 
 ### Config
 


### PR DESCRIPTION
## Summary
Updated the README to document additional Claude Code configuration directories that are part of the project setup.

## Changes
- Added documentation for `.claude/hooks/*.sh` directory for shell hook scripts
- Added documentation for `.claude/rules/*.md` directory for markdown rule files

These directories are now listed alongside the existing `.claude/settings.json` configuration file in the Claude Code project settings section.

https://claude.ai/code/session_01N5i5KHf3xLiYACQh6viXDL