### PR TITLE
feat: use CLAUDE_PROJECT_DIR in hook paths and simplify mcp config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/ensure-jj.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/ensure-jj.sh\""
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/prefer-jj.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/prefer-jj.sh\""
           }
         ]
       }

--- a/.devenv.json
+++ b/.devenv.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.1.0",
+  "installedAt": "2026-02-19T13:56:28.177Z",
+  "modules": [
+    ".",
+    ".devcontainer",
+    ".github",
+    ".claude"
+  ],
+  "source": {
+    "owner": "tktcorporation",
+    "repo": ".github"
+  }
+}

--- a/.devenv/modules.jsonc
+++ b/.devenv/modules.jsonc
@@ -7,7 +7,11 @@
       "name": "Root",
       "description": "MCP, mise, and other root-level config files",
       "setupDescription": "Root config files will be applied",
-      "patterns": [".mcp.json", ".mise.toml"],
+      "patterns": [
+        ".mcp.json",
+        ".mise.toml",
+        ".devenv.json"
+      ],
     },
     {
       "id": ".devcontainer",

--- a/.mcp.json
+++ b/.mcp.json
@@ -5,18 +5,6 @@
       "command": "bash",
       "args": [".devcontainer/run-chrome-devtools-mcp.sh"],
       "env": {}
-    },
-    "context7": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp"],
-      "env": {}
-    },
-    "ide": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@anthropic-ai/ide-mcp@latest"],
-      "env": {}
     }
   }
 }


### PR DESCRIPTION
## Summary
- `.claude/settings.json`: フックのコマンドパスを `$CLAUDE_PROJECT_DIR` ベースに変更し、どのディレクトリから呼び出しても正しくパスが解決されるようにした
- `.mcp.json`: 不要な設定を削除してシンプルに
- `.devenv.json`: devenv メタデータファイルを追加（track 対象に含めた）
- `.devenv/modules.jsonc`: `.devenv.json` の追跡パターンを追加
