### PR TITLE
feat: use CLAUDE_PROJECT_DIR in hook paths and simplify mcp config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/ensure-jj.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/ensure-jj.sh\""
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/prefer-jj.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/prefer-jj.sh\""
           }
         ]
       }

--- a/.mcp.json
+++ b/.mcp.json
@@ -5,18 +5,6 @@
       "command": "bash",
       "args": [".devcontainer/run-chrome-devtools-mcp.sh"],
       "env": {}
-    },
-    "context7": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp"],
-      "env": {}
-    },
-    "ide": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@anthropic-ai/ide-mcp@latest"],
-      "env": {}
     }
   }
 }


### PR DESCRIPTION
## Summary
- `.claude/settings.json`: フックのコマンドパスを `$CLAUDE_PROJECT_DIR` ベースに変更し、どのディレクトリから呼び出しても正しくパスが解決されるようにした
- `.mcp.json`: 不要な設定を削除してシンプルに
