### PR TITLE
Auto-delete manifest file after successful PR creation

### DIFF
--- a/.changeset/auto-delete-manifest.md
+++ b/.changeset/auto-delete-manifest.md
@@ -1,0 +1,5 @@
+---
+"@tktco/create-devenv": patch
+---
+
+`push --execute` でPR作成成功後に `.devenv-push-manifest.yaml` を自動削除するように変更

--- a/packages/create-devenv/src/commands/push.ts
+++ b/packages/create-devenv/src/commands/push.ts
@@ -23,6 +23,7 @@ import {
 import { detectDiff, formatDiff, getPushableFiles } from "../utils/diff";
 import { createPullRequest, getGitHubToken } from "../utils/github";
 import {
+  deleteManifest,
   generateManifest,
   getSelectedFilePaths,
   getSelectedUntrackedFiles,
@@ -350,6 +351,9 @@ async function runExecuteMode(
       }),
     );
 
+    // マニフェストファイルを自動削除（PR作成に成功したので不要）
+    await deleteManifest(targetDir);
+
     // 成功メッセージ
     box("Pull request created!", "success");
 
@@ -358,12 +362,12 @@ async function runExecuteMode(
     console.log(`  ${pc.bold("Files:")}  ${files.length} files included`);
     log.newline();
 
+    log.dim(`Cleaned up ${MANIFEST_FILENAME}`);
+    log.newline();
+
     showNextSteps([
       {
         description: `Review and merge the PR at ${result.url}`,
-      },
-      {
-        description: `Delete ${MANIFEST_FILENAME} after PR is merged`,
       },
     ]);
   } finally {

--- a/packages/create-devenv/src/utils/__tests__/manifest.test.ts
+++ b/packages/create-devenv/src/utils/__tests__/manifest.test.ts
@@ -14,6 +14,7 @@ vi.mock("node:fs", async () => {
 
 // モック後にインポート
 const {
+  deleteManifest,
   generateManifest,
   serializeManifest,
   saveManifest,
@@ -188,6 +189,28 @@ describe("manifestExists", () => {
     vol.fromJSON({});
 
     expect(manifestExists("/project")).toBe(false);
+  });
+});
+
+describe("deleteManifest", () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it("マニフェストファイルを削除できる", async () => {
+    vol.fromJSON({
+      [`/project/${MANIFEST_FILENAME}`]: "version: 1",
+    });
+
+    expect(manifestExists("/project")).toBe(true);
+    await deleteManifest("/project");
+    expect(manifestExists("/project")).toBe(false);
+  });
+
+  it("マニフェストファイルが存在しない場合でもエラーにならない", async () => {
+    vol.fromJSON({});
+
+    await expect(deleteManifest("/project")).resolves.not.toThrow();
   });
 });
 

--- a/packages/create-devenv/src/utils/manifest.ts
+++ b/packages/create-devenv/src/utils/manifest.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "pathe";
 import { stringify, parse } from "yaml";
 import type { FileDiff, PushManifest, DiffResult } from "../modules/schemas";
@@ -191,6 +191,19 @@ export async function loadManifest(targetDir: string): Promise<PushManifest> {
   }
 
   return result.data;
+}
+
+/**
+ * マニフェストファイルを削除する。
+ *
+ * 背景: --execute でPR作成が成功した後、マニフェストはもう不要なので自動的にクリーンアップする。
+ * ファイルが存在しない場合は何もしない。
+ */
+export async function deleteManifest(targetDir: string): Promise<void> {
+  const manifestPath = join(targetDir, MANIFEST_FILENAME);
+  if (existsSync(manifestPath)) {
+    await rm(manifestPath);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
Automatically delete the `.devenv-push-manifest.yaml` manifest file after a pull request is successfully created in `push --execute` mode, eliminating the need for manual cleanup.

## Key Changes
- **New function `deleteManifest()`**: Added to `manifest.ts` to safely remove the manifest file. The function checks if the file exists before deletion and gracefully handles cases where the file is already missing.
- **Integration in push command**: Modified `runExecuteMode()` in `push.ts` to call `deleteManifest()` immediately after successful PR creation.
- **Updated user messaging**: Replaced the "Delete manifest after PR is merged" step in the next steps guidance with a confirmation message that the manifest was cleaned up.
- **Comprehensive test coverage**: Added test cases for the new `deleteManifest()` function covering both successful deletion and the case where the file doesn't exist.

## Implementation Details
- The `deleteManifest()` function uses `existsSync()` to check for file existence before attempting deletion via `rm()` from `node:fs/promises`, preventing errors when the file is already absent.
- The cleanup happens synchronously in the success path of PR creation, ensuring the manifest is removed before displaying success messages to the user.
- This change improves the user experience by automating a previously manual cleanup step.

https://claude.ai/code/session_01ASkxkkNiMpcygW3KxoD3mw