### PR TITLE
ci: add changeset check for berm package

### DIFF
--- a/.changeset/redesign-cli-clack-prompts.md
+++ b/.changeset/redesign-cli-clack-prompts.md
@@ -1,0 +1,10 @@
+---
+"@tktco/berm": minor
+---
+
+Redesign CLI with @clack/prompts and unified error handling
+
+- Replace @inquirer/prompts + nanospinner with @clack/prompts for consistent UI
+- Introduce BermError for structured error handling with optional hints
+- Add unified UI layer (renderer, prompts, diff-view modules)
+- Remove old prompt and UI utility files

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,44 @@
+name: Changeset Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  changeset-check:
+    name: Check for changeset
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changeset files
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # Get changed files in this PR compared to base branch
+          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+
+          # Check if berm package code changed (exclude auto-generated files)
+          CODE_CHANGES=$(echo "$CHANGED_FILES" | grep -E '^packages/berm/src/' || true)
+          if [ -z "$CODE_CHANGES" ]; then
+            echo "No berm code changes detected, skipping changeset check"
+            exit 0
+          fi
+
+          echo "Detected berm code changes:"
+          echo "$CODE_CHANGES"
+          echo ""
+
+          # Check if a changeset file was added
+          CHANGESET_FILES=$(echo "$CHANGED_FILES" | grep -E '^\.changeset/.+\.md$' | grep -v 'README.md' || true)
+          if [ -z "$CHANGESET_FILES" ]; then
+            echo "::error::No changeset found. Please run 'pnpm changeset' to create one."
+            echo ""
+            echo "If this change doesn't need a release, add an empty changeset with 'pnpm changeset --empty'."
+            exit 1
+          fi
+
+          echo "Changeset found:"
+          echo "$CHANGESET_FILES"


### PR DESCRIPTION
## Summary

- Add `changeset-check.yml` workflow that fails PRs when `packages/berm/src/` has changes but no `.changeset/*.md` is included
- Add missing changeset for PR #95 (CLI redesign with @clack/prompts)

## Details

### Changeset Check CI
- Runs on PRs to `main`
- Detects code changes in `packages/berm/src/`
- Skips if only non-code files changed (docs, CI config, etc.)
- Fails with actionable error message when changeset is missing
- Suggests `pnpm changeset --empty` for changes that don't need a release

Same mechanism as cross-recorder repo.

### Missing Changeset
- Added changeset for PR #95: berm CLI redesign with @clack/prompts and unified error handling (minor)

## Test plan
- [ ] Verify CI passes on this PR (changeset is included)
- [ ] Create a test PR with berm code changes but no changeset → should fail
- [ ] Create a test PR with only non-code changes → should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)