### PR TITLE
Show diff preview before PR confirmation & fix temp dir cleanup

### DIFF
--- a/.changeset/preview-changes-and-cleanup.md
+++ b/.changeset/preview-changes-and-cleanup.md
@@ -1,0 +1,8 @@
+---
+"@tktco/berm": minor
+---
+
+push: 確認前に差分プレビューを表示 & Ctrl+C 時の一時ディレクトリクリーンアップ
+
+- Push summary の後、"Create PR?" の前にファイルごとの unified diff を表示するようにした。変更内容を確認してから判断できる。
+- Ctrl+C (process.exit) で終了した場合に .devenv-temp が残る問題を修正。process.on('exit') で同期クリーンアップを登録。

--- a/packages/berm/src/commands/__tests__/push.test.ts
+++ b/packages/berm/src/commands/__tests__/push.test.ts
@@ -32,6 +32,8 @@ vi.mock("../../utils/template", () => ({
 vi.mock("../../utils/diff", () => ({
   detectDiff: vi.fn(),
   getPushableFiles: vi.fn(() => []),
+  generateUnifiedDiff: vi.fn(() => ""),
+  colorizeUnifiedDiff: vi.fn((s: string) => s),
 }));
 
 // utils/github をモック

--- a/packages/berm/src/commands/push.ts
+++ b/packages/berm/src/commands/push.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { readFile, rm } from "node:fs/promises";
 import { defineCommand } from "citty";
 import { downloadTemplate } from "giget";
@@ -23,7 +23,12 @@ import {
   selectPushFiles,
 } from "../ui/prompts";
 import { intro, log, logDiffSummary, outro, pc, withSpinner } from "../ui/renderer";
-import { detectDiff, getPushableFiles } from "../utils/diff";
+import {
+  colorizeUnifiedDiff,
+  detectDiff,
+  generateUnifiedDiff,
+  getPushableFiles,
+} from "../utils/diff";
 import { createPullRequest, getGitHubToken } from "../utils/github";
 import {
   deleteManifest,
@@ -37,6 +42,31 @@ import {
 import { detectAndUpdateReadme } from "../utils/readme";
 import { buildTemplateSource } from "../utils/template";
 import { detectUntrackedFiles } from "../utils/untracked";
+
+/**
+ * process.exit() でも確実に一時ディレクトリを削除するための同期クリーンアップを登録する。
+ *
+ * 背景: handleCancel() が process.exit(0) を呼ぶため async finally ブロックが
+ * スキップされ、.devenv-temp が残る問題への対策。process.on('exit') は
+ * process.exit() でも発火するが同期処理のみ実行可能なため rmSync を使用。
+ *
+ * 削除条件: handleCancel() が process.exit() を使わなくなった場合。
+ */
+function registerSyncCleanup(tempDir: string): () => void {
+  const cleanup = () => {
+    try {
+      if (existsSync(tempDir)) {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    } catch {
+      // プロセス終了中のエラーは無視（ベストエフォート）
+    }
+  };
+  process.on("exit", cleanup);
+  return () => {
+    process.removeListener("exit", cleanup);
+  };
+}
 
 const MODULES_FILE_PATH = ".devenv/modules.jsonc";
 const README_PATH = "README.md";
@@ -175,6 +205,7 @@ async function runExecuteMode(
 
   const templateSource = buildTemplateSource(config.source);
   const tempDir = join(targetDir, ".devenv-temp");
+  const unregisterCleanup = registerSyncCleanup(tempDir);
 
   try {
     const { dir: templateDir } = await withSpinner("Downloading template from GitHub...", () =>
@@ -356,6 +387,7 @@ async function runExecuteMode(
     log.message(pc.dim(`Cleaned up ${MANIFEST_FILENAME}`));
     outro(`Review and merge the PR at ${result.url}`);
   } finally {
+    unregisterCleanup();
     // 一時ディレクトリを削除
     if (existsSync(tempDir)) {
       await rm(tempDir, { recursive: true, force: true });
@@ -474,6 +506,7 @@ export const pushCommand = defineCommand({
     // テンプレートを一時ディレクトリにダウンロード
     const templateSource = buildTemplateSource(config.source);
     const tempDir = join(targetDir, ".devenv-temp");
+    const unregisterCleanup = registerSyncCleanup(tempDir);
 
     try {
       const { dir: templateDir } = await withSpinner("Downloading template from GitHub...", () =>
@@ -820,6 +853,18 @@ export const pushCommand = defineCommand({
         ].join("\n"),
       );
 
+      // ファイルごとの差分プレビューを表示
+      // 確認前に変更内容を把握できるようにする
+      log.step("Changes");
+      for (const pf of pushableFiles) {
+        // files に含まれるもの（選択済み or 全ファイル）のみ表示
+        if (!files.some((f) => f.path === pf.path)) continue;
+        const unifiedDiff = generateUnifiedDiff(pf);
+        if (unifiedDiff) {
+          log.message(colorizeUnifiedDiff(unifiedDiff));
+        }
+      }
+
       if (!args.force) {
         const confirmed = await confirmAction("Create PR?", { initialValue: true });
         if (!confirmed) {
@@ -853,6 +898,7 @@ export const pushCommand = defineCommand({
       );
       outro(`Review and merge the PR at ${result.url}`);
     } finally {
+      unregisterCleanup();
       // 一時ディレクトリを削除
       if (existsSync(tempDir)) {
         await rm(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
This PR improves the push command UX by displaying file diffs before PR confirmation, and fixes a bug where temporary directories weren't cleaned up when the process was interrupted with Ctrl+C.

## Key Changes
- **Diff Preview**: Display unified diffs for each file before the "Create PR?" confirmation prompt, allowing users to review changes before committing to the PR
- **Cleanup on Exit**: Register a synchronous cleanup handler via `process.on('exit')` to ensure `.devenv-temp` is deleted even when `process.exit()` is called (e.g., on Ctrl+C)
- **New Utilities**: Import and use `generateUnifiedDiff` and `colorizeUnifiedDiff` from the diff utils module
- **Test Updates**: Mock the new diff utility functions in the push command tests

## Implementation Details
- The `registerSyncCleanup()` function uses `rmSync` (synchronous) instead of `rm` (async) because `process.on('exit')` only supports synchronous operations
- The cleanup handler is registered at the start of both `runExecuteMode()` and the main `pushCommand` handler, and unregistered in their finally blocks
- The diff preview is shown after the push summary but before the confirmation prompt, giving users a final chance to review changes
- The implementation includes Japanese comments explaining the rationale for the synchronous cleanup approach

https://claude.ai/code/session_011pnvP9e817XaVadtnqyo7F