### PR TITLE
Refactor pull/push UX: conflict resolution workflow and git-like output

### DIFF
--- a/.changeset/improve-push-ux.md
+++ b/.changeset/improve-push-ux.md
@@ -1,0 +1,11 @@
+---
+"@tktco/berm": patch
+---
+
+Improve `berm push` UX to feel more like `git push`
+
+- Show git-style "To owner/repo → branch" header with file stats (`+N -M`) in push summary
+- Highlight commit hash (baseRef) in conflict warnings so users know exactly which version conflicts with
+- Post-push success output now shows branch name and PR number in git-push format
+- `--select` mode shows line-count hints (`+N -M`) alongside each file in the multiselect
+- Unresolved conflict messages now include a clear hint to run `berm pull`

--- a/.changeset/refactor-pull-upstream-fix.md
+++ b/.changeset/refactor-pull-upstream-fix.md
@@ -1,0 +1,16 @@
+---
+"@tktco/berm": patch
+---
+
+refactor(pull): upstream fixes — remove duplicate conflict logic and type workarounds
+
+- Use `hasConflictMarkers()` from merge.ts in `runContinue` instead of raw `includes("<<<<<<<")`.
+  Previously the check was incomplete (missing `=======` / `>>>>>>>` detection) and duplicated
+  existing utility logic.
+- Collapse the `base あり/なし` branch in Step 8 into a single code path using `""` as the
+  default base. The only difference was the first argument to `threeWayMerge`; the conflict
+  logging was identical copypaste.
+- Extract `logMergeConflict()` helper so conflict reporting is defined once.
+- Change `getInstalledModulePatterns` parameter type from `{ excludePatterns?: string[] }` to
+  `DevEnvConfig`, removing the `config as any` cast.
+- Remove unused `getPatternsByModuleIds` import.

--- a/packages/berm/CHANGELOG.md
+++ b/packages/berm/CHANGELOG.md
@@ -45,7 +45,6 @@
   テンプレートの最新変更をローカルに取り込む `berm pull` コマンドを追加。
   3-way マージエンジンにより、ローカルの変更を保持しつつテンプレート更新を適用する。
   コンフリクト時はマーカーを挿入し、ユーザーが手動解決できる。
-
   - 新規: `berm pull` コマンド
   - 新規: 3-way マージエンジン (`utils/merge.ts`)
   - 新規: ファイルハッシュユーティリティ (`utils/hash.ts`)
@@ -112,7 +111,6 @@
 - [#74](https://github.com/tktcorporation/.github/pull/74) [`64b3475`](https://github.com/tktcorporation/.github/commit/64b3475c39362cadc4a332fa3eeb91c7f5d8c12f) Thanks [@tktcorporation](https://github.com/tktcorporation)! - feat: add `track` command for non-interactive file tracking management
 
   AI エージェントが非インタラクティブにファイルパターンを `.devenv/modules.jsonc` のホワイトリストに追加できる `track` コマンドを追加。
-
   - `npx @tktco/berm track ".cloud/rules/*.md"` でパターン追加（モジュール自動検出）
   - `--module` オプションで明示的にモジュール指定可能
   - 存在しないモジュールは自動作成（`--name`, `--description` でカスタマイズ可能）
@@ -148,7 +146,6 @@
 ### Minor Changes
 
 - [#61](https://github.com/tktcorporation/.github/pull/61) [`41ea99b`](https://github.com/tktcorporation/.github/commit/41ea99b9c0ed8f9fbe88c976735577cece92636c) Thanks [@tktcorporation](https://github.com/tktcorporation)! - Add AI-agent friendly manifest-based push workflow
-
   - `--prepare` option: Generates a YAML manifest file (`.devenv-push-manifest.yaml`) for reviewing and editing file selections
   - `--execute` option: Creates a PR based on the manifest file without interactive prompts
 
@@ -159,7 +156,6 @@
 ### Patch Changes
 
 - [#51](https://github.com/tktcorporation/.github/pull/51) [`71d6e04`](https://github.com/tktcorporation/.github/commit/71d6e04edd297f79e56d1a6df40262da2e22d2a4) Thanks [@tktcorporation](https://github.com/tktcorporation)! - feat(init): gitignore 対象ファイルの同期時の挙動を改善
-
   - init 時に gitignore 対象のファイルがローカルに既存在する場合、上書きせずスキップして警告を表示
   - gitignore 対象のファイルがローカルに存在しない場合は、通常通りコピー
   - push 時は gitignore 対象ファイルを追跡対象から除外（既存の動作を維持）
@@ -176,7 +172,6 @@
 ### Minor Changes
 
 - [#45](https://github.com/tktcorporation/.github/pull/45) [`4557ba0`](https://github.com/tktcorporation/.github/commit/4557ba09b019d2f8f0dbaad3f274d6c4e56c9731) Thanks [@tktcorporation](https://github.com/tktcorporation)! - feat(berm): improve diff display with summary box and interactive viewer
-
   - Add new diff-viewer.ts with modern box-styled summary display
   - Show file changes grouped by type (added/modified/deleted) with line stats
   - Add interactive diff viewer with n/p navigation between files
@@ -190,7 +185,6 @@
 ### Patch Changes
 
 - [#47](https://github.com/tktcorporation/.github/pull/47) [`052075d`](https://github.com/tktcorporation/.github/commit/052075dd830d4ccc8eae4b949a73db164e903df7) Thanks [@tktcorporation](https://github.com/tktcorporation)! - テストを大幅に拡充
-
   - config.ts: 設定ファイルの読み書きテスト
   - patterns.ts: パターンマッチングとマージのテスト
   - modules/schemas.ts: Zod スキーマバリデーションテスト
@@ -251,20 +245,17 @@
 - [#23](https://github.com/tktcorporation/.github/pull/23) [`ec36c47`](https://github.com/tktcorporation/.github/commit/ec36c474aac4e01b30ad018507f5fe7f9a305da2) Thanks [@tktcorporation](https://github.com/tktcorporation)! - push コマンドにホワイトリスト外ファイル検知機能を追加し、モジュール定義を外部化
 
   ### ホワイトリスト外ファイル検知
-
   - push 時にホワイトリスト（patterns）に含まれていないファイルを検出
   - モジュールごとにグループ化して選択 UI を表示
   - 選択したファイルを modules.jsonc に自動追加（PR に含まれる）
   - gitignore されているファイルは自動で除外
 
   ### モジュール定義の外部化
-
   - モジュール定義をコードから `.devenv/modules.jsonc` に外部化
   - テンプレートリポジトリの modules.jsonc から動的に読み込み
   - `customPatterns` を廃止し modules.jsonc に統合
 
   ### ディレクトリベースのモジュール設計
-
   - モジュール ID をディレクトリパスベースに変更（例: `.devcontainer`, `.github`, `.`）
   - ファイルパスから即座にモジュール ID を導出可能に
   - モジュール間のファイル重複を構造的に防止
@@ -274,7 +265,6 @@
 ### Minor Changes
 
 - [#14](https://github.com/tktcorporation/.github/pull/14) [`c026ed5`](https://github.com/tktcorporation/.github/commit/c026ed55da57df6599f7c57cdbb5d29c05e3273d) Thanks [@tktcorporation](https://github.com/tktcorporation)! - .gitignore に記載されたファイルを自動的に除外する機能を追加
-
   - init, diff, push の全コマンドで .gitignore にマッチするファイルを除外
   - ローカルディレクトリとテンプレートリポジトリ両方の .gitignore をチェック
   - クレデンシャル等の機密情報の誤流出を防止
@@ -291,12 +281,10 @@
 - [#12](https://github.com/tktcorporation/.github/pull/12) [`798d3fb`](https://github.com/tktcorporation/.github/commit/798d3fb332bdffbc4feac24d9ed89a1b510d7fcf) Thanks [@tktcorporation](https://github.com/tktcorporation)! - 双方向同期機能とホワイトリスト形式を追加
 
   ### 新機能
-
   - `push` コマンド: ローカル変更を GitHub PR として自動送信
   - `diff` コマンド: ローカルとテンプレートの差分をプレビュー
 
   ### 破壊的変更
-
   - モジュール定義を `files` + `excludeFiles` 形式から `patterns` (glob) 形式に移行
   - テンプレート対象ファイルをホワイトリスト形式で明示的に指定するように変更
 
@@ -332,7 +320,6 @@
 ### Patch Changes
 
 - [#4](https://github.com/tktcorporation/.github/pull/4) [`ae7c5e7`](https://github.com/tktcorporation/.github/commit/ae7c5e712b1a16963cd0cd920a92dd589f5e9f84) Thanks [@tktcorporation](https://github.com/tktcorporation)! - fix: overwriteStrategy オプションが正しく機能するように修正
-
   - "prompt" 戦略: ファイルごとにユーザーに上書き確認を表示
   - "skip" 戦略: 既存ファイルをスキップして新規ファイルのみコピー
   - "overwrite" 戦略: 既存ファイルを全て上書き

--- a/packages/berm/src/commands/__tests__/pull.test.ts
+++ b/packages/berm/src/commands/__tests__/pull.test.ts
@@ -32,6 +32,10 @@ vi.mock("../../utils/hash", () => ({
 vi.mock("../../utils/merge", () => ({
   classifyFiles: vi.fn(),
   threeWayMerge: vi.fn(),
+  hasConflictMarkers: vi.fn((content: string) => ({
+    found: content.includes("<<<<<<<"),
+    lines: [],
+  })),
 }));
 
 vi.mock("../../utils/github", () => ({

--- a/packages/berm/src/commands/__tests__/pull.test.ts
+++ b/packages/berm/src/commands/__tests__/pull.test.ts
@@ -423,6 +423,117 @@ describe("pullCommand", () => {
       expect(mockCleanup).toHaveBeenCalled();
     });
 
+    it("コンフリクト時に pendingMerge を保存して中断", async () => {
+      vol.fromJSON({
+        "/test/.mcp.json": "local content",
+        "/tmp/template/.mcp.json": "template content",
+      });
+
+      mockClassifyFiles.mockReturnValueOnce({
+        autoUpdate: [],
+        localOnly: [],
+        conflicts: [".mcp.json"],
+        newFiles: [],
+        deletedFiles: [],
+        unchanged: [],
+      });
+
+      mockThreeWayMerge.mockReturnValueOnce({
+        content: "<<<<<<< LOCAL\nlocal\n=======\ntemplate\n>>>>>>> TEMPLATE",
+        hasConflicts: true,
+        conflictDetails: [],
+      });
+
+      await (pullCommand.run as any)({
+        args: { dir: "/test", force: false, continue: false },
+        rawArgs: [],
+        cmd: pullCommand,
+      });
+
+      expect(mockSaveConfig).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          pendingMerge: expect.objectContaining({
+            conflicts: [".mcp.json"],
+          }),
+        }),
+      );
+      // baseHashes/baseRef は更新されない（pendingMerge に保留）
+      expect(mockSaveConfig).not.toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ baseHashes: expect.any(Object), pendingMerge: undefined }),
+      );
+    });
+
+    it("--continue: pendingMerge がない場合はエラー", async () => {
+      mockLoadConfig.mockResolvedValueOnce({
+        ...baseConfig,
+        pendingMerge: undefined,
+      });
+
+      await expect(
+        (pullCommand.run as any)({
+          args: { dir: "/test", force: false, continue: true },
+          rawArgs: [],
+          cmd: pullCommand,
+        }),
+      ).rejects.toThrow(BermError);
+    });
+
+    it("--continue: コンフリクトマーカーが残っている場合はエラー", async () => {
+      vol.fromJSON({
+        "/test/.mcp.json": "<<<<<<< LOCAL\nlocal\n=======\ntemplate\n>>>>>>> TEMPLATE",
+      });
+
+      mockLoadConfig.mockResolvedValueOnce({
+        ...baseConfig,
+        pendingMerge: {
+          conflicts: [".mcp.json"],
+          templateHashes: { ".mcp.json": "hash123" },
+          latestRef: "latest123",
+        },
+      });
+
+      await expect(
+        (pullCommand.run as any)({
+          args: { dir: "/test", force: false, continue: true },
+          rawArgs: [],
+          cmd: pullCommand,
+        }),
+      ).rejects.toThrow(BermError);
+    });
+
+    it("--continue: 全解決済みなら baseHashes/baseRef を更新して pendingMerge を削除", async () => {
+      vol.fromJSON({
+        "/test/.mcp.json": "resolved content (no conflict markers)",
+      });
+
+      mockLoadConfig.mockResolvedValueOnce({
+        ...baseConfig,
+        pendingMerge: {
+          conflicts: [".mcp.json"],
+          templateHashes: { ".mcp.json": "newhash" },
+          latestRef: "newref123",
+        },
+      });
+
+      await (pullCommand.run as any)({
+        args: { dir: "/test", force: false, continue: true },
+        rawArgs: [],
+        cmd: pullCommand,
+      });
+
+      expect(mockSaveConfig).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          baseHashes: { ".mcp.json": "newhash" },
+          baseRef: "newref123",
+          pendingMerge: undefined,
+        }),
+      );
+      expect(mockLog.success).toHaveBeenCalledWith("All conflicts resolved");
+    });
+
     it("エラー時も cleanup が呼ばれる", async () => {
       const mockCleanup = vi.fn();
       mockDownloadTemplateToTemp.mockResolvedValue({

--- a/packages/berm/src/commands/__tests__/push.test.ts
+++ b/packages/berm/src/commands/__tests__/push.test.ts
@@ -119,6 +119,7 @@ vi.mock("../../ui/renderer", () => ({
     dim: (s: string) => s,
     green: (s: string) => s,
     yellow: (s: string) => s,
+    red: (s: string) => s,
   },
   withSpinner: vi.fn(async (_text: string, fn: () => Promise<unknown>) => fn()),
 }));
@@ -538,9 +539,7 @@ describe("pushCommand", () => {
         cmd: pushCommand,
       });
 
-      expect(mockLog.warn).toHaveBeenCalledWith(
-        "Template has also changed 1 file(s) since last pull/init. Attempting auto-merge...",
-      );
+      expect(mockLog.warn).toHaveBeenCalledWith(expect.stringContaining("Template updated"));
       expect(mockLog.info).toHaveBeenCalledWith(
         "Run `berm pull` first to sync template changes, then push again.",
       );

--- a/packages/berm/src/commands/pull.ts
+++ b/packages/berm/src/commands/pull.ts
@@ -45,6 +45,11 @@ export const pullCommand = defineCommand({
       description: "Skip confirmations",
       default: false,
     },
+    continue: {
+      type: "boolean",
+      description: "Continue after resolving merge conflicts",
+      default: false,
+    },
   },
   async run({ args }) {
     intro("pull");
@@ -57,6 +62,12 @@ export const pullCommand = defineCommand({
       config = await loadConfig(targetDir);
     } catch {
       throw new BermError("Not initialized", "Run `berm init` first");
+    }
+
+    // --continue モード: コンフリクト解決後の状態更新
+    if (args.continue) {
+      await runContinue(targetDir, config);
+      return;
     }
 
     if (config.modules.length === 0) {
@@ -207,10 +218,25 @@ export const pullCommand = defineCommand({
           }
 
           if (hasUnresolvedConflicts) {
-            log.warn("Some files have conflicts. Please resolve them manually.");
+            log.warn("Some files have conflicts. Resolve them, then run `berm pull --continue`");
           }
         } finally {
           baseCleanup?.();
+        }
+
+        if (hasUnresolvedConflicts) {
+          // pendingMerge を保存して中断。baseHashes/baseRef は --continue 後に更新する。
+          const latestRef = await resolveLatestCommitSha(config.source.owner, config.source.repo);
+          await saveConfig(targetDir, {
+            ...config,
+            pendingMerge: {
+              conflicts: classification.conflicts,
+              templateHashes: templateHashes,
+              ...(latestRef ? { latestRef } : {}),
+            },
+          });
+          outro("Merge paused — resolve conflicts then run `berm pull --continue`");
+          return;
         }
       }
 
@@ -253,6 +279,61 @@ export const pullCommand = defineCommand({
     }
   },
 });
+
+/**
+ * `--continue` モードの処理: コンフリクト解決後に baseHashes/baseRef を更新する。
+ *
+ * 背景: `berm pull` でコンフリクトが発生した際、ユーザーが手動解決した後に
+ * `berm pull --continue` を実行することで状態更新が完了する。
+ * git の `git merge --continue` / `git rebase --continue` パターンを踏襲。
+ *
+ * 対になる操作: pull.ts の pendingMerge 保存ロジック（コンフリクト発生時）
+ */
+async function runContinue(
+  targetDir: string,
+  config: import("../modules/schemas").DevEnvConfig,
+): Promise<void> {
+  if (!config.pendingMerge) {
+    throw new BermError("No pending merge found", "Run `berm pull` first to start a merge");
+  }
+
+  const { conflicts, templateHashes, latestRef } = config.pendingMerge;
+
+  // コンフリクトマーカーが残っていないか確認
+  const stillConflicted: string[] = [];
+  for (const file of conflicts) {
+    try {
+      const content = await readFile(join(targetDir, file), "utf-8");
+      if (content.includes("<<<<<<<")) {
+        stillConflicted.push(file);
+      }
+    } catch {
+      // ファイルが存在しない場合は解決済みとみなす（削除により解決）
+    }
+  }
+
+  if (stillConflicted.length > 0) {
+    for (const file of stillConflicted) {
+      log.warn(`Still has conflict markers: ${pc.cyan(file)}`);
+    }
+    throw new BermError(
+      "Unresolved conflicts remain",
+      "Resolve all conflict markers then run `berm pull --continue` again",
+    );
+  }
+
+  // 全て解決済み: baseHashes/baseRef を更新して pendingMerge を削除
+  const updatedConfig = {
+    ...config,
+    baseHashes: templateHashes,
+    ...(latestRef ? { baseRef: latestRef } : {}),
+    pendingMerge: undefined,
+  };
+  await saveConfig(targetDir, updatedConfig);
+
+  log.success("All conflicts resolved");
+  outro("Pull complete");
+}
 
 /**
  * インストール済みモジュールの有効パターンを全て取得する。

--- a/packages/berm/src/commands/pull.ts
+++ b/packages/berm/src/commands/pull.ts
@@ -3,19 +3,15 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { defineCommand } from "citty";
 import { dirname, join, resolve } from "pathe";
 import { BermError } from "../errors";
-import {
-  defaultModules,
-  getPatternsByModuleIds,
-  loadModulesFile,
-  modulesFileExists,
-} from "../modules";
-import type { TemplateModule } from "../modules/schemas";
+import { defaultModules, loadModulesFile, modulesFileExists } from "../modules";
+import type { DevEnvConfig, TemplateModule } from "../modules/schemas";
 import { selectDeletedFiles } from "../ui/prompts";
 import { intro, log, outro, pc, withSpinner } from "../ui/renderer";
 import { loadConfig, saveConfig } from "../utils/config";
 import { resolveLatestCommitSha } from "../utils/github";
 import { hashFiles } from "../utils/hash";
-import { classifyFiles, threeWayMerge } from "../utils/merge";
+import { classifyFiles, hasConflictMarkers, threeWayMerge } from "../utils/merge";
+import type { MergeResult } from "../utils/merge";
 import { downloadTemplateToTemp } from "../utils/template";
 import { getEffectivePatterns } from "../utils/patterns";
 
@@ -174,46 +170,17 @@ export const pullCommand = defineCommand({
             const localContent = await readFile(join(targetDir, file), "utf-8");
             const templateContent = await readFile(join(templateDir, file), "utf-8");
 
-            // baseRef のテンプレートからベース内容を読む
-            let baseContent: string | undefined;
+            // base がない場合は "" をデフォルトとして使う（共通祖先が空 = 新規追加のマージ相当）
+            let baseContent = "";
             if (baseTemplateDir && existsSync(join(baseTemplateDir, file))) {
               baseContent = await readFile(join(baseTemplateDir, file), "utf-8");
             }
 
-            if (baseContent !== undefined) {
-              // 3-way マージ（ファイルパスを渡して構造マージを有効化）
-              const result = threeWayMerge(baseContent, localContent, templateContent, file);
-              await writeFile(join(targetDir, file), result.content, "utf-8");
-              if (result.hasConflicts) {
-                hasUnresolvedConflicts = true;
-                if (result.conflictDetails.length > 0) {
-                  // 構造マージ: ファイルは壊れていないがキーレベルのコンフリクトあり
-                  log.warn(`Conflict in ${pc.cyan(file)} — review these keys:`);
-                  for (const detail of result.conflictDetails) {
-                    const pathStr = detail.path.join(".");
-                    log.message(`  ${pc.dim("•")} ${pc.yellow(pathStr)} — kept local value`);
-                  }
-                } else {
-                  log.warn(`Conflict in ${pc.cyan(file)} — manual resolution needed`);
-                }
-              }
-            } else {
-              // base がない場合も構造マージを試みる（JSON/JSONC の場合）
-              // base がないので空オブジェクトを仮の base として使用
-              const result = threeWayMerge("", localContent, templateContent, file);
-              await writeFile(join(targetDir, file), result.content, "utf-8");
-              if (result.hasConflicts) {
-                hasUnresolvedConflicts = true;
-                if (result.conflictDetails.length > 0) {
-                  log.warn(`Conflict in ${pc.cyan(file)} — review these keys:`);
-                  for (const detail of result.conflictDetails) {
-                    const pathStr = detail.path.join(".");
-                    log.message(`  ${pc.dim("•")} ${pc.yellow(pathStr)} — kept local value`);
-                  }
-                } else {
-                  log.warn(`Conflict in ${pc.cyan(file)} — manual resolution needed`);
-                }
-              }
+            const result = threeWayMerge(baseContent, localContent, templateContent, file);
+            await writeFile(join(targetDir, file), result.content, "utf-8");
+            if (result.hasConflicts) {
+              hasUnresolvedConflicts = true;
+              logMergeConflict(file, result);
             }
           }
 
@@ -289,10 +256,7 @@ export const pullCommand = defineCommand({
  *
  * 対になる操作: pull.ts の pendingMerge 保存ロジック（コンフリクト発生時）
  */
-async function runContinue(
-  targetDir: string,
-  config: import("../modules/schemas").DevEnvConfig,
-): Promise<void> {
+async function runContinue(targetDir: string, config: DevEnvConfig): Promise<void> {
   if (!config.pendingMerge) {
     throw new BermError("No pending merge found", "Run `berm pull` first to start a merge");
   }
@@ -304,7 +268,7 @@ async function runContinue(
   for (const file of conflicts) {
     try {
       const content = await readFile(join(targetDir, file), "utf-8");
-      if (content.includes("<<<<<<<")) {
+      if (hasConflictMarkers(content).found) {
         stillConflicted.push(file);
       }
     } catch {
@@ -336,6 +300,26 @@ async function runContinue(
 }
 
 /**
+ * 1ファイルのマージ結果をユーザーに報告する。
+ *
+ * 背景: JSON/JSONC の構造マージ（conflictDetails あり）とテキストマージ（conflictMarkers あり）で
+ * メッセージが異なるため、このヘルパーに集約する。
+ * Step 8 と他の呼び出し元でログ出力のロジックを共有する。
+ */
+function logMergeConflict(file: string, result: MergeResult): void {
+  if (result.conflictDetails.length > 0) {
+    // 構造マージ: ファイルは壊れていないがキーレベルのコンフリクトあり
+    log.warn(`Conflict in ${pc.cyan(file)} — review these keys:`);
+    for (const detail of result.conflictDetails) {
+      const pathStr = detail.path.join(".");
+      log.message(`  ${pc.dim("•")} ${pc.yellow(pathStr)} — kept local value`);
+    }
+  } else {
+    log.warn(`Conflict in ${pc.cyan(file)} — manual resolution needed`);
+  }
+}
+
+/**
  * インストール済みモジュールの有効パターンを全て取得する。
  *
  * 背景: pull 時にハッシュ計算対象のファイルを特定するため、
@@ -344,13 +328,13 @@ async function runContinue(
 function getInstalledModulePatterns(
   moduleIds: string[],
   moduleList: TemplateModule[],
-  config: { excludePatterns?: string[] },
+  config: DevEnvConfig,
 ): string[] {
   const patterns: string[] = [];
   for (const moduleId of moduleIds) {
     const mod = moduleList.find((m) => m.id === moduleId);
     if (!mod) continue;
-    patterns.push(...getEffectivePatterns(moduleId, mod.patterns, config as any));
+    patterns.push(...getEffectivePatterns(moduleId, mod.patterns, config));
   }
   return patterns;
 }

--- a/packages/berm/src/commands/push.ts
+++ b/packages/berm/src/commands/push.ts
@@ -525,6 +525,15 @@ export const pushCommand = defineCommand({
       return;
     }
 
+    // pendingMerge がある場合はコンフリクト未解決のためブロック
+    if (config.pendingMerge) {
+      throw new BermError(
+        "Unresolved merge conflicts from `berm pull`",
+        "Resolve conflicts in these files, then run `berm pull --continue`:\n" +
+          config.pendingMerge.conflicts.map((f) => `  • ${f}`).join("\n"),
+      );
+    }
+
     // --execute モード: マニフェストファイルを使ってPRを作成
     if (args.execute) {
       await runExecuteMode(targetDir, config, args.message);

--- a/packages/berm/src/commands/push.ts
+++ b/packages/berm/src/commands/push.ts
@@ -23,12 +23,7 @@ import {
   selectPushFiles,
 } from "../ui/prompts";
 import { intro, log, logDiffSummary, outro, pc, withSpinner } from "../ui/renderer";
-import {
-  colorizeUnifiedDiff,
-  detectDiff,
-  generateUnifiedDiff,
-  getPushableFiles,
-} from "../utils/diff";
+import { detectDiff, getPushableFiles } from "../utils/diff";
 import { createPullRequest, getGitHubToken } from "../utils/github";
 import {
   deleteManifest,
@@ -42,6 +37,41 @@ import {
 import { detectAndUpdateReadme } from "../utils/readme";
 import { buildTemplateSource } from "../utils/template";
 import { detectUntrackedFiles } from "../utils/untracked";
+
+/**
+ * FileDiff の差分統計を "+N -M" 形式でフォーマットする。
+ *
+ * 背景: git push の出力に合わせ、変更行数を可視化する。
+ * "modified" の場合は行数の差を表示（詳細な unified diff は berm diff で確認可能）。
+ */
+function formatFileStat(file: {
+  type: string;
+  localContent?: string;
+  templateContent?: string;
+}): string {
+  let additions = 0;
+  let deletions = 0;
+
+  if (file.type === "added" && file.localContent) {
+    additions = file.localContent.split("\n").length;
+  } else if (file.type === "deleted" && file.templateContent) {
+    deletions = file.templateContent.split("\n").length;
+  } else if (file.type === "modified") {
+    const local = file.localContent?.split("\n").length ?? 0;
+    const tmpl = file.templateContent?.split("\n").length ?? 0;
+    additions = Math.max(0, local - tmpl);
+    deletions = Math.max(0, tmpl - local);
+    if (additions === 0 && deletions === 0 && file.localContent !== file.templateContent) {
+      additions = 1;
+      deletions = 1;
+    }
+  }
+
+  const parts: string[] = [];
+  if (additions > 0) parts.push(pc.green(`+${additions}`));
+  if (deletions > 0) parts.push(pc.red(`-${deletions}`));
+  return parts.length > 0 ? parts.join(" ") : pc.dim("~");
+}
 
 /**
  * process.exit() でも確実に一時ディレクトリを削除するための同期クリーンアップを登録する。
@@ -375,17 +405,18 @@ async function runExecuteMode(
     // マニフェストファイルを自動削除（PR作成に成功したので不要）
     await deleteManifest(targetDir);
 
-    // 成功メッセージ
+    // 成功メッセージ — git push の "To repo branch" 形式に準拠
     log.success("Pull request created!");
     log.message(
       [
-        `URL:    ${pc.cyan(result.url)}`,
-        `Branch: ${result.branch}`,
-        `Files:  ${files.length} files included`,
+        `${pc.dim("To")} ${pc.bold(`${config.source.owner}/${config.source.repo}`)}`,
+        `  ${pc.green(result.branch)}  ${pc.dim(`(${files.length} file${files.length !== 1 ? "s" : ""} changed)`)}`,
+        "",
+        `  ${pc.bold(`PR #${result.number}`)}  ${pc.cyan(result.url)}`,
       ].join("\n"),
     );
     log.message(pc.dim(`Cleaned up ${MANIFEST_FILENAME}`));
-    outro(`Review and merge the PR at ${result.url}`);
+    outro(`Review and merge at ${pc.cyan(result.url)}`);
   } finally {
     unregisterCleanup();
     // 一時ディレクトリを削除
@@ -585,8 +616,12 @@ export const pushCommand = defineCommand({
         if (classification.conflicts.length > 0) {
           const { threeWayMerge } = await import("../utils/merge");
 
+          // baseRef がある場合はハッシュを強調表示する（git の "non-fast-forward" エラーに相当）
+          const baseInfo = config.baseRef
+            ? `since ${pc.bold(config.baseRef.slice(0, 7))} (your last sync)`
+            : "since your last pull/init";
           log.warn(
-            `Template has also changed ${classification.conflicts.length} file(s) since last pull/init. Attempting auto-merge...`,
+            `Template updated ${baseInfo} — ${classification.conflicts.length} conflict(s) detected, attempting auto-merge...`,
           );
 
           // baseRef が存在すれば、ベースバージョンを再ダウンロードして 3-way マージ
@@ -645,16 +680,19 @@ export const pushCommand = defineCommand({
             if (unresolved.length > 0) {
               log.warn(`${unresolved.length} file(s) could not be auto-merged:`);
               for (const file of unresolved) {
-                log.message(`  ${pc.yellow("⚠")} ${file}`);
+                log.message(`  ${pc.yellow("!")} ${file}`);
               }
               log.message(
-                pc.dim(
-                  "Your PR will include your local version for these files. The reviewer can compare with upstream.",
-                ),
+                [
+                  pc.dim("Your local changes will be included in the PR."),
+                  pc.dim(
+                    `hint: Run ${pc.cyan("berm pull")} to sync changes first, then push again.`,
+                  ),
+                ].join("\n"),
               );
 
               if (!args.yes) {
-                const proceed = await confirmAction("Continue with push?", {
+                const proceed = await confirmAction("Continue with unresolved conflicts?", {
                   initialValue: true,
                 });
                 if (!proceed) {
@@ -842,28 +880,44 @@ export const pushCommand = defineCommand({
         });
       }
 
-      // Step 4: サマリー表示 + 確認
-      log.step("Push summary");
-      const fileIcons = files.map((f) => `  ${pc.dim("•")} ${f.path}`);
-      log.message(
-        [
-          `${pc.bold("Title:")} ${title}`,
-          `${pc.bold("Files:")} ${files.length} file(s)`,
-          ...fileIcons,
-        ].join("\n"),
-      );
+      // Step 4: git-like なサマリー表示 + 確認
+      // "To owner/repo → branch" 形式でプッシュ先と変更内容を一覧表示する。
+      // 詳細な unified diff は `berm diff` で確認可能。
+      const destination = `${config.source.owner}/${config.source.repo}`;
+      const baseBranch = config.source.ref || "main";
+      const baseHashStr = config.baseRef
+        ? `  ${pc.dim(`since ${config.baseRef.slice(0, 7)}`)}`
+        : "";
 
-      // ファイルごとの差分プレビューを表示
-      // 確認前に変更内容を把握できるようにする
-      log.step("Changes");
+      // 変更ファイル行の生成（type アイコン + パス + 行数統計）
+      const fileLines: string[] = [];
       for (const pf of pushableFiles) {
-        // files に含まれるもの（選択済み or 全ファイル）のみ表示
         if (!files.some((f) => f.path === pf.path)) continue;
-        const unifiedDiff = generateUnifiedDiff(pf);
-        if (unifiedDiff) {
-          log.message(colorizeUnifiedDiff(unifiedDiff));
+        const stat = formatFileStat(pf);
+        const icon =
+          pf.type === "added"
+            ? pc.green("+")
+            : pf.type === "modified"
+              ? pc.yellow("~")
+              : pc.red("-");
+        fileLines.push(`  ${icon} ${pf.path.padEnd(50)} ${stat}`);
+      }
+      // pushableFiles に含まれない追加ファイル（modules.jsonc、README 自動更新等）
+      for (const f of files) {
+        if (!pushableFiles.some((pf) => pf.path === f.path)) {
+          fileLines.push(`  ${pc.green("+")} ${f.path.padEnd(50)} ${pc.dim("(auto-updated)")}`);
         }
       }
+
+      log.message(
+        [
+          `${pc.dim("To")} ${pc.bold(destination)}  ${pc.dim(`→ ${baseBranch}`)}${baseHashStr}`,
+          pc.dim("─".repeat(62)),
+          ...fileLines,
+          pc.dim("─".repeat(62)),
+          `  ${pc.dim("PR:")} ${title}`,
+        ].join("\n"),
+      );
 
       if (!args.yes) {
         const confirmed = await confirmAction("Create PR?", { initialValue: true });
@@ -887,16 +941,17 @@ export const pushCommand = defineCommand({
         }),
       );
 
-      // 成功メッセージ
+      // 成功メッセージ — git push の "To repo branch" 形式に準拠
       log.success("Pull request created!");
       log.message(
         [
-          `URL:    ${pc.cyan(result.url)}`,
-          `Branch: ${result.branch}`,
-          `Files:  ${files.length} files included`,
+          `${pc.dim("To")} ${pc.bold(`${config.source.owner}/${config.source.repo}`)}`,
+          `  ${config.baseRef ? `${pc.dim(config.baseRef.slice(0, 7))}..` : ""}${pc.green(result.branch)}  ${pc.dim(`(${files.length} file${files.length !== 1 ? "s" : ""} changed)`)}`,
+          "",
+          `  ${pc.bold(`PR #${result.number}`)}  ${pc.cyan(result.url)}`,
         ].join("\n"),
       );
-      outro(`Review and merge the PR at ${result.url}`);
+      outro(`Review and merge at ${pc.cyan(result.url)}`);
     } finally {
       unregisterCleanup();
       // 一時ディレクトリを削除

--- a/packages/berm/src/modules/schemas.ts
+++ b/packages/berm/src/modules/schemas.ts
@@ -70,6 +70,24 @@ export const configSchema = z.object({
    * 「ユーザーが変更したか」を判定できるようにするため。
    */
   baseHashes: z.record(z.string(), z.string()).optional(),
+  /**
+   * pull 中のコンフリクト解決待ち状態。
+   *
+   * 背景: `berm pull` でコンフリクトが発生した場合、ユーザーが手動解決してから
+   * `berm pull --continue` を実行するまでの間、この状態が保持される。
+   * `berm push` はこのフィールドが存在する間ブロックされる。
+   * 解決完了後 `berm pull --continue` により削除される。
+   */
+  pendingMerge: z
+    .object({
+      /** コンフリクトマーカーを確認すべきファイルパス一覧 */
+      conflicts: z.array(z.string()),
+      /** pull 対象のテンプレートハッシュ（解決後の baseHashes として適用） */
+      templateHashes: z.record(z.string(), z.string()),
+      /** pull 対象の最新コミット SHA（解決後の baseRef として適用） */
+      latestRef: z.string().optional(),
+    })
+    .optional(),
 });
 
 export type DevEnvConfig = z.infer<typeof configSchema>;

--- a/packages/berm/src/ui/prompts.ts
+++ b/packages/berm/src/ui/prompts.ts
@@ -67,7 +67,41 @@ export async function selectOverwriteStrategy(options?: {
 
 // ─── push ─────────────────────────────────────────────────────
 
-/** push 対象ファイルの選択 */
+/**
+ * ファイルの行数統計を "+N -M" 形式で返す（hint テキスト用）。
+ * git push の出力に合わせ、変更規模をひと目で把握できるようにする。
+ */
+function fileStatHint(file: FileDiff): string {
+  let additions = 0;
+  let deletions = 0;
+
+  if (file.type === "added" && file.localContent) {
+    additions = file.localContent.split("\n").length;
+  } else if (file.type === "deleted" && file.templateContent) {
+    deletions = file.templateContent.split("\n").length;
+  } else if (file.type === "modified") {
+    const local = file.localContent?.split("\n").length ?? 0;
+    const tmpl = file.templateContent?.split("\n").length ?? 0;
+    additions = Math.max(0, local - tmpl);
+    deletions = Math.max(0, tmpl - local);
+    if (additions === 0 && deletions === 0 && file.localContent !== file.templateContent) {
+      additions = 1;
+      deletions = 1;
+    }
+  }
+
+  const parts: string[] = [];
+  if (additions > 0) parts.push(pc.green(`+${additions}`));
+  if (deletions > 0) parts.push(pc.red(`-${deletions}`));
+  return parts.join(" ");
+}
+
+/**
+ * push 対象ファイルの選択（+N -M 統計付き）
+ *
+ * 背景: git の `git add -p` に相当するファイル選択 UI。
+ * 変更規模（行数増減）をヒントとして表示し、何を同期するか判断しやすくする。
+ */
 export async function selectPushFiles(files: FileDiff[]): Promise<FileDiff[]> {
   const typeIcon = (type: string) => {
     switch (type) {
@@ -84,10 +118,14 @@ export async function selectPushFiles(files: FileDiff[]): Promise<FileDiff[]> {
 
   const selected = await p.multiselect({
     message: "Select files to include in PR",
-    options: files.map((f) => ({
-      value: f.path,
-      label: `${typeIcon(f.type)} ${f.path}`,
-    })),
+    options: files.map((f) => {
+      const hint = fileStatHint(f);
+      return {
+        value: f.path,
+        label: `${typeIcon(f.type)} ${f.path}`,
+        hint: hint || undefined,
+      };
+    }),
     initialValues: files.map((f) => f.path),
     required: false,
   });


### PR DESCRIPTION
## Summary

This PR improves the `berm pull` and `berm push` commands with a two-part enhancement:

1. **Pull conflict resolution workflow**: Implements a `--continue` flag pattern (similar to `git merge --continue`) to handle merge conflicts in two steps—detect and pause, then resume after manual resolution.
2. **Push UX improvements**: Reformats output to match `git push` conventions with file statistics, clearer conflict messaging, and better visual hierarchy.

## Key Changes

### Pull Command (`pull.ts`)
- **New `--continue` flag**: Allows resuming a paused merge after manual conflict resolution
- **`pendingMerge` state**: Saves conflict information and template hashes when conflicts are detected, blocking `berm push` until resolved
- **`runContinue()` function**: Validates that all conflict markers have been resolved, then updates `baseHashes`/`baseRef` and clears `pendingMerge`
- **Simplified merge logic**: Collapsed duplicate `baseContent` branches into a single code path using `""` as default base
- **`logMergeConflict()` helper**: Extracted conflict reporting to eliminate copypaste between structural and text-based conflicts
- **Improved messaging**: Changed "Please resolve them manually" to "Resolve them, then run `berm pull --continue`"

### Push Command (`push.ts`)
- **Git-style output format**: Changed success message from `URL: / Branch: / Files:` to `To owner/repo → branch` with PR number
- **File statistics**: Added `+N -M` line-count display in push summary (via new `formatFileStat()` helper)
- **Conflict detection messaging**: Now shows `baseRef` hash slice to clarify which template version conflicts with local changes
- **Unresolved conflict hints**: Added suggestion to run `berm pull` when auto-merge fails
- **Multiselect UI enhancement**: File selection now shows line-count hints (`+N -M`) for each file

### Config Schema (`modules/schemas.ts`)
- **`pendingMerge` field**: New optional object storing:
  - `conflicts`: Array of file paths with unresolved markers
  - `templateHashes`: Template hashes to apply after resolution
  - `latestRef`: Latest commit SHA (optional)

### Tests (`pull.test.ts`, `push.test.ts`)
- Added test cases for `--continue` flag behavior
- Tests for conflict marker detection and validation
- Tests for `pendingMerge` state transitions

### UI Improvements (`prompts.ts`)
- **`fileStatHint()` helper**: Calculates line-count statistics for display in file selection
- Enhanced multiselect options with hint text showing change magnitude

## Implementation Details

- **Conflict marker detection**: Uses existing `hasConflictMarkers()` utility from `merge.ts` instead of raw string checks
- **Type safety**: Removed `config as any` cast by using proper `DevEnvConfig` type
- **Cleanup**: Removed unused `getPatternsByModuleIds` import
- **Backward compatibility**: `pendingMerge` is optional; existing configs work unchanged
- **Push blocking**: `berm push` now throws an error if `pendingMerge` exists, with clear instructions on which files need resolution

## Changeset Files

- `refactor-pull-upstream-fix.md`: Documents code cleanup and type improvements
- `improve-push-ux.md`: Documents UX enhancements to match git conventions

https://claude.ai/code/session_01TXN4yQb8vdDbnQyfB24SxU