### PR TITLE
refactor(docs): FILESセクションをモジュール単位の表示に変更

### DIFF
--- a/packages/berm/README.md
+++ b/packages/berm/README.md
@@ -170,45 +170,12 @@ npx @tktco/berm ai-docs
 
 Files generated based on selected modules:
 
-### Root
+- **Root (`./`)** — MCP, mise, and other root-level config files
+- **`.devcontainer/`** — VS Code DevContainer with Docker-in-Docker
+- **`.github/`** — GitHub Actions and labeler workflows
+- **`.claude/`** — Claude Code project settings
 
-MCP, mise, and other root-level config files
-
-- `.mcp.json`
-- `.mise.toml`
-
-### `.devcontainer/`
-
-VS Code DevContainer with Docker-in-Docker
-
-- `.devcontainer/devcontainer.json`
-- `.devcontainer/.gitignore`
-- `.devcontainer/setup-*.sh`
-- `.devcontainer/test-*.sh`
-- `.devcontainer/.env.devcontainer.example`
-- `.devcontainer/run-chrome-devtools-mcp.sh`
-
-### `.github/`
-
-GitHub Actions and labeler workflows
-
-- `.github/workflows/issue-link.yml`
-- `.github/workflows/label.yml`
-- `.github/labeler.yml`
-
-### `.claude/`
-
-Claude Code project settings
-
-- `.claude/settings.json`
-- `.claude/hooks/*.sh`
-- `.claude/rules/*.md`
-- `.claude/rules/jujutsu.md`
-- `.claude/skills/upstream-fix/SKILL.md`
-
-### Config
-
-- `.devenv.json` - Tracks which modules are applied
+> See [`.devenv/modules.jsonc`](./.devenv/modules.jsonc) for the full list of tracked file patterns.
 
 <!-- FILES:END -->
 

--- a/packages/berm/scripts/generate-readme.ts
+++ b/packages/berm/scripts/generate-readme.ts
@@ -177,28 +177,31 @@ function cleanUsageOutput(usage: string): string {
 /**
  * Generate What You Get section
  */
+/**
+ * モジュールのディレクトリ単位の概要のみを表示する。個別パターンは列挙しない。
+ *
+ * 背景: 個別パターンを列挙すると、既存モジュール内にファイルを1つ追加するだけで
+ * docs:check が失敗してしまう。パターン詳細は modules.jsonc が正規の置き場であり、
+ * README に二重管理する必要はない。
+ *
+ * モジュール追加（新フォルダ単位）はREADME変更を伴うが、
+ * 既存モジュール内のパターン追加はREADMEに影響しない。
+ */
 function generateFilesSection(modules: TemplateModule[]): string {
   const lines: string[] = [];
   lines.push("## What You Get\n");
   lines.push("Files generated based on selected modules:\n");
 
   for (const mod of modules) {
-    // Get directory name from module ID
-    const dirName = mod.id === "." ? "Root" : `\`${mod.id}/\``;
-    lines.push(`### ${dirName}\n`);
-    lines.push(`${mod.description}\n`);
-
-    for (const pattern of mod.patterns) {
-      // Display glob patterns descriptively
-      const displayPattern = pattern.includes("*") ? `\`${pattern}\`` : `\`${pattern}\``;
-      lines.push(`- ${displayPattern}`);
-    }
-    lines.push("");
+    const dirName = mod.id === "." ? "Root (`./`)" : `\`${mod.id}/\``;
+    lines.push(`- **${dirName}** — ${mod.description}`);
   }
 
-  // Add config file description
-  lines.push("### Config\n");
-  lines.push("- `.devenv.json` - Tracks which modules are applied\n");
+  lines.push("");
+  lines.push(
+    "> See [`.devenv/modules.jsonc`](./.devenv/modules.jsonc) for the full list of tracked file patterns.",
+  );
+  lines.push("");
 
   return lines.join("\n");
 }


### PR DESCRIPTION
個別パターンをすべて列挙していたため、既存モジュール内にファイルを1つ
追加するだけで docs:check が失敗する問題があった。

パターン詳細は modules.jsonc が正規の置き場のため、READMEにはモジュールの
ディレクトリ単位の概要のみを表示し、詳細は modules.jsonc へのリンクに委ねる。

これにより berm track 後に毎回 pnpm run docs を実行しなくて済む。

https://claude.ai/code/session_01XAv1bTSfWq8bTsvph59Y3f