### PR TITLE
fix: show Auto-merged message when conflict files are resolved by 3-way merge

### DIFF
--- a/.changeset/auto-merge-feedback.md
+++ b/.changeset/auto-merge-feedback.md
@@ -1,0 +1,5 @@
+---
+"ziku": patch
+---
+
+Show "Auto-merged" success message when conflict files are resolved by 3-way merge

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -1,5 +1,22 @@
 # PR ワークフロールール
 
+## プッシュ前の必須チェック（CRITICAL）
+
+**コードを push する前に、以下を必ず順番に実行すること。1つでも漏れたら push 禁止。**
+
+1. `pnpm --filter ziku run check` で CI 相当の全チェックを通す（format, lint, build, test, docs）
+2. changeset ファイルが必要か確認する（機能追加・バグ修正なら必須）
+   - `ls .changeset/*.md` で README.md 以外のファイルがあるか確認
+   - なければ `.changeset/<名前>.md` を作成
+3. 全部通ったことを確認してから `git push`
+
+```bash
+# チェックリスト（コピペ用）
+pnpm --filter ziku run check         # 全チェック一括
+ls .changeset/*.md                    # changeset 確認
+# ↑ 両方 OK なら push
+```
+
 ## PR 作成後の CI ウォッチ
 
 PR を作成した後は、必ず CI が完了するまでウォッチする。
@@ -26,6 +43,7 @@ gh pr checks <PR番号> --watch
 ```
 
 形式:
+
 ```markdown
 ---
 "cross-recorder": minor

--- a/packages/ziku/src/commands/__tests__/pull.test.ts
+++ b/packages/ziku/src/commands/__tests__/pull.test.ts
@@ -559,6 +559,180 @@ describe("pullCommand", () => {
       expect(mockCleanup).toHaveBeenCalled();
     });
 
+    it("コンフリクトファイルが自動マージ成功した場合に success ログを出す", async () => {
+      vol.fromJSON({
+        "/test/.mcp.json": "local content",
+        "/tmp/template/.mcp.json": "template content",
+      });
+
+      mockClassifyFiles.mockReturnValueOnce({
+        autoUpdate: [],
+        localOnly: [],
+        conflicts: [".mcp.json"],
+        newFiles: [],
+        deletedFiles: [],
+        unchanged: [],
+      });
+
+      // 自動マージ成功（hasConflicts: false）
+      mockThreeWayMerge.mockReturnValueOnce({
+        content: "auto-merged content",
+        hasConflicts: false,
+        conflictDetails: [],
+      });
+
+      await (pullCommand.run as any)({
+        args: { dir: "/test", force: false },
+        rawArgs: [],
+        cmd: pullCommand,
+      });
+
+      // 自動マージ成功のメッセージが出力される
+      expect(mockLog.success).toHaveBeenCalledWith(expect.stringContaining("Auto-merged"));
+      expect(mockLog.success).toHaveBeenCalledWith(expect.stringContaining(".mcp.json"));
+      // pendingMerge は保存されない（正常完了パス）
+      expect(mockSaveConfig).not.toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ pendingMerge: expect.anything() }),
+      );
+    });
+
+    it("複数コンフリクトで一部自動マージ・一部未解決の場合に各ログが出る", async () => {
+      vol.fromJSON({
+        "/test/a.json": "local a",
+        "/test/b.txt": "local b",
+        "/tmp/template/a.json": "template a",
+        "/tmp/template/b.txt": "template b",
+      });
+
+      mockClassifyFiles.mockReturnValueOnce({
+        autoUpdate: [],
+        localOnly: [],
+        conflicts: ["a.json", "b.txt"],
+        newFiles: [],
+        deletedFiles: [],
+        unchanged: [],
+      });
+
+      // a.json: 自動マージ成功
+      mockThreeWayMerge.mockReturnValueOnce({
+        content: "merged a",
+        hasConflicts: false,
+        conflictDetails: [],
+      });
+      // b.txt: コンフリクト（テキストマーカー）
+      mockThreeWayMerge.mockReturnValueOnce({
+        content: "<<<<<<< LOCAL\nlocal b\n=======\ntemplate b\n>>>>>>> TEMPLATE",
+        hasConflicts: true,
+        conflictDetails: [],
+      });
+
+      await (pullCommand.run as any)({
+        args: { dir: "/test", force: false },
+        rawArgs: [],
+        cmd: pullCommand,
+      });
+
+      // a.json は自動マージ成功
+      expect(mockLog.success).toHaveBeenCalledWith(expect.stringContaining("Auto-merged"));
+      expect(mockLog.success).toHaveBeenCalledWith(expect.stringContaining("a.json"));
+      // b.txt はコンフリクト
+      expect(mockLog.warn).toHaveBeenCalledWith(expect.stringContaining("b.txt"));
+      // 未解決コンフリクトがあるので pendingMerge が保存される
+      expect(mockSaveConfig).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          pendingMerge: expect.objectContaining({
+            conflicts: ["b.txt"],
+          }),
+        }),
+      );
+    });
+
+    it("全コンフリクトが自動マージ成功した場合は pendingMerge なしで正常完了", async () => {
+      vol.fromJSON({
+        "/test/a.json": "local a",
+        "/test/b.json": "local b",
+        "/tmp/template/a.json": "template a",
+        "/tmp/template/b.json": "template b",
+      });
+
+      mockClassifyFiles.mockReturnValueOnce({
+        autoUpdate: [],
+        localOnly: [],
+        conflicts: ["a.json", "b.json"],
+        newFiles: [],
+        deletedFiles: [],
+        unchanged: [],
+      });
+
+      mockThreeWayMerge.mockReturnValueOnce({
+        content: "merged a",
+        hasConflicts: false,
+        conflictDetails: [],
+      });
+      mockThreeWayMerge.mockReturnValueOnce({
+        content: "merged b",
+        hasConflicts: false,
+        conflictDetails: [],
+      });
+
+      await (pullCommand.run as any)({
+        args: { dir: "/test", force: false },
+        rawArgs: [],
+        cmd: pullCommand,
+      });
+
+      // 両方自動マージ成功
+      expect(mockLog.success).toHaveBeenCalledWith(expect.stringContaining("a.json"));
+      expect(mockLog.success).toHaveBeenCalledWith(expect.stringContaining("b.json"));
+      // pendingMerge なしで正常完了
+      expect(mockSaveConfig).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          baseHashes: expect.any(Object),
+        }),
+      );
+      expect(mockSaveConfig).not.toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          pendingMerge: expect.anything(),
+        }),
+      );
+    });
+
+    it("JSON 構造マージでキーレベルコンフリクト時は warn を出す（既存動作）", async () => {
+      vol.fromJSON({
+        "/test/config.json": '{"version": "2.0"}',
+        "/tmp/template/config.json": '{"version": "3.0"}',
+      });
+
+      mockClassifyFiles.mockReturnValueOnce({
+        autoUpdate: [],
+        localOnly: [],
+        conflicts: ["config.json"],
+        newFiles: [],
+        deletedFiles: [],
+        unchanged: [],
+      });
+
+      mockThreeWayMerge.mockReturnValueOnce({
+        content: '{"version": "2.0"}',
+        hasConflicts: true,
+        conflictDetails: [{ path: ["version"], localValue: "2.0", templateValue: "3.0" }],
+      });
+
+      await (pullCommand.run as any)({
+        args: { dir: "/test", force: false },
+        rawArgs: [],
+        cmd: pullCommand,
+      });
+
+      // キーレベルコンフリクトの warn
+      expect(mockLog.warn).toHaveBeenCalledWith(expect.stringContaining("config.json"));
+      expect(mockLog.warn).toHaveBeenCalledWith(expect.stringContaining("review these keys"));
+    });
+
     it("新規ファイル追加時にディレクトリを自動作成", async () => {
       vol.fromJSON({
         "/test": null,

--- a/packages/ziku/src/commands/pull.ts
+++ b/packages/ziku/src/commands/pull.ts
@@ -147,7 +147,7 @@ export const pullCommand = defineCommand({
       }
 
       // Step 8: コンフリクト解決
-      let hasUnresolvedConflicts = false;
+      const unresolvedConflicts: string[] = [];
       if (classification.conflicts.length > 0) {
         // baseRef が存在する場合、ベースバージョンを再ダウンロードして 3-way マージ
         let baseTemplateDir: string | undefined;
@@ -179,25 +179,28 @@ export const pullCommand = defineCommand({
             const result = threeWayMerge(baseContent, localContent, templateContent, file);
             await writeFile(join(targetDir, file), result.content, "utf-8");
             if (result.hasConflicts) {
-              hasUnresolvedConflicts = true;
+              unresolvedConflicts.push(file);
               logMergeConflict(file, result);
+            } else {
+              log.success(`Auto-merged: ${pc.cyan(file)}`);
             }
           }
 
-          if (hasUnresolvedConflicts) {
+          if (unresolvedConflicts.length > 0) {
             log.warn("Some files have conflicts. Resolve them, then run `ziku pull --continue`");
           }
         } finally {
           baseCleanup?.();
         }
 
-        if (hasUnresolvedConflicts) {
+        if (unresolvedConflicts.length > 0) {
           // pendingMerge を保存して中断。baseHashes/baseRef は --continue 後に更新する。
+          // 自動マージ成功したファイルは含めず、未解決ファイルのみ記録する。
           const latestRef = await resolveLatestCommitSha(config.source.owner, config.source.repo);
           await saveConfig(targetDir, {
             ...config,
             pendingMerge: {
-              conflicts: classification.conflicts,
+              conflicts: unresolvedConflicts,
               templateHashes: templateHashes,
               ...(latestRef ? { latestRef } : {}),
             },


### PR DESCRIPTION
When files classified as "conflicts" (both local and template modified) were
auto-resolved by the 3-way merge, no feedback was shown to the user — they
saw "!1 conflicts" in the summary but then just "Pull complete" with no
explanation of what happened. Now shows "Auto-merged: <file>" for each
successfully merged file. Also tracks only unresolved files in pendingMerge.

https://claude.ai/code/session_012VagdEnnV4v7B1b7pNaTMC