### PR TITLE
Fix environment variable loading in Codespaces devcontainer

### DIFF
--- a/.devcontainer/.env.devcontainer.example
+++ b/.devcontainer/.env.devcontainer.example
@@ -1,5 +1,10 @@
 # 環境変数サンプル
-# このファイルを devcontainer.env にコピーして値を設定してください
+# このファイルを .env.devcontainer にコピーして値を設定してください
+#
+# ローカル devcontainer: runArgs --env-file で自動ロード
+# Codespaces: runArgs が無効なため、load-env-to-profile.sh がシェルプロファイルに追加
+#             または Codespaces secrets に同名で設定すれば remoteEnv 経由で注入される
+
 
 # GitHub Personal Access Token
 GH_TOKEN=

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,26 @@
     "source=devcontainer-shared-mise-data,target=/home/vscode/.local/share/mise,type=volume"
   ],
 
+  // Codespaces 環境変数の転送
+  // Codespaces では runArgs --env-file が無視されるため、remoteEnv で補完する。
+  // Codespaces: リポジトリの Codespaces secrets に設定した値が ${localEnv:...} 経由で注入される
+  // ローカル: ホストマシンの環境変数から注入される（.env.devcontainer と併用可）
+  // Claude Code OAuth 認証のコールバック用ポートフォワーディング
+  // claude login 実行時にローカル HTTP サーバーが起動し、ブラウザからのリダイレクトを受け取る
+  // Codespaces ではポートフォワーディングが必要（ローカルでは不要だが設定しても害はない）
+  "forwardPorts": [7160, 7161, 7162, 7163, 7164],
+  "portsAttributes": {
+    "7160-7164": {
+      "label": "Claude OAuth Callback",
+      "onAutoForward": "silent"
+    }
+  },
+
+  "remoteEnv": {
+    "GH_TOKEN": "${localEnv:GH_TOKEN}",
+    "WAKATIME_API_KEY": "${localEnv:WAKATIME_API_KEY}"
+  },
+
   "features": {
     // "ghcr.io/devcontainers/features/docker-in-docker:2": {
     //   "version": "latest",
@@ -120,6 +140,9 @@
     ]
   },
   "postStartCommand": {
+    // Codespaces では runArgs --env-file が無効なため、
+    // .env.devcontainer の内容をシェルプロファイルに追加して補完する
+    "load-env-to-profile": ["bash", "-lc", ".devcontainer/load-env-to-profile.sh"],
     "setup-chrome-devtools-mcp": ["bash", "-lc", ".devcontainer/setup-chrome-devtools-mcp.sh"],
     "mise-upgrade": ["mise", "upgrade"],
     "check-env-file": [

--- a/.devcontainer/load-env-to-profile.sh
+++ b/.devcontainer/load-env-to-profile.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Codespaces では runArgs --env-file が無視されるため、
+# .env.devcontainer の内容をシェルプロファイルに追加して
+# ターミナルセッションで環境変数を利用可能にする。
+#
+# ローカル devcontainer では runArgs で既にロード済みだが、
+# 二重設定しても害はない（同じ値が上書きされるだけ）。
+#
+# 動作条件:
+#   - .env.devcontainer が存在し、中身がある場合のみ実行
+#   - コメント行・空行はスキップ
+#   - 既に設定済みの環境変数は上書きしない（remoteEnv / runArgs 優先）
+
+set -euo pipefail
+
+WORKSPACE_DIR="${CONTAINER_WORKSPACE_FOLDER:-/workspaces/$(basename "$PWD")}"
+ENV_FILE="${WORKSPACE_DIR}/.devcontainer/.env.devcontainer"
+PROFILE_SNIPPET="$HOME/.env.devcontainer.profile"
+
+if [ ! -s "$ENV_FILE" ]; then
+  echo "load-env-to-profile: .env.devcontainer is empty or missing, skipping."
+  exit 0
+fi
+
+# .env ファイルから export 文を生成（既存の変数は上書きしない）
+{
+  echo "# Auto-generated from .env.devcontainer — do not edit"
+  while IFS= read -r line || [ -n "$line" ]; do
+    # コメント行・空行をスキップ
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    # KEY=VALUE 形式のみ処理
+    if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)= ]]; then
+      key="${BASH_REMATCH[1]}"
+      # 既に設定済みなら上書きしない（remoteEnv / Codespaces secrets 優先）
+      echo "export ${key}=\"\${${key}:-${line#*=}}\""
+    fi
+  done < "$ENV_FILE"
+} > "$PROFILE_SNIPPET"
+
+# bashrc / zshrc に source 行を追加（重複防止）
+for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+  if [ -f "$rc" ] && ! grep -qF "$PROFILE_SNIPPET" "$rc"; then
+    echo "[ -f \"$PROFILE_SNIPPET\" ] && source \"$PROFILE_SNIPPET\"" >> "$rc"
+  fi
+done
+
+echo "load-env-to-profile: loaded env vars from .env.devcontainer into shell profile."


### PR DESCRIPTION
## Summary
This PR fixes environment variable loading in GitHub Codespaces by implementing a workaround for the limitation where `runArgs --env-file` is ignored in Codespaces environments.

## Key Changes
- **New script**: Added `.devcontainer/load-env-to-profile.sh` that loads environment variables from `.env.devcontainer` into shell profiles (bashrc/zshrc) at container startup
- **Updated devcontainer.json**: 
  - Added `postStartCommand` entry to execute the new load-env script
  - Added `remoteEnv` configuration to inject `GH_TOKEN` and `WAKATIME_API_KEY` from local environment or Codespaces secrets
  - Added port forwarding configuration (ports 7160-7164) for Claude OAuth callback handling
- **Updated documentation**: Modified `.env.devcontainer.example` to clarify the different loading mechanisms for local devcontainer vs Codespaces environments

## Implementation Details
- The load script safely handles the `.env.devcontainer` file by:
  - Skipping comment lines and empty lines
  - Only processing `KEY=VALUE` format entries
  - Preserving existing environment variables (not overwriting values set via `remoteEnv` or Codespaces secrets)
  - Preventing duplicate source statements in shell profiles
- The solution is backward compatible with local devcontainer setups where `runArgs --env-file` already works
- Port forwarding is configured for Claude OAuth authentication callback handling in Codespaces

https://claude.ai/code/session_01P7rnzjw93jBVcedUJRwT6z