### PR TITLE
Add cooldown mechanism and improved error handling to jj installer

### DIFF
--- a/.claude/hooks/ensure-jj.sh
+++ b/.claude/hooks/ensure-jj.sh
@@ -9,6 +9,14 @@ if command -v jj &>/dev/null; then
   exit 0
 fi
 
+# 1.5. $HOME/bin/jj が既にダウンロード済みなら PATH に追加して終了
+# SessionStart hook は毎回新しいシェルで実行されるため、前回のインストールで
+# PATH に追加した設定が引き継がれない。ここで既存バイナリを検出して再ダウンロードを防ぐ。
+if [ -x "${HOME}/bin/jj" ]; then
+  echo "jj $(${HOME}/bin/jj version 2>/dev/null || echo '(version unknown)') を ${HOME}/bin で検出しました"
+  exit 0
+fi
+
 # 2. mise 経由でインストールを試みる
 if command -v mise &>/dev/null; then
   echo "jj が見つかりません。mise 経由でインストールします..."

--- a/.claude/hooks/ensure-jj.sh
+++ b/.claude/hooks/ensure-jj.sh
@@ -17,6 +17,30 @@ if [ -x "${HOME}/bin/jj" ]; then
   exit 0
 fi
 
+# 1.9. インストール失敗のクールダウン機構
+# 前回のインストール試行が失敗していた場合、一定期間（24時間）はスキップする。
+# ネットワーク不通・非対応プラットフォーム等で毎セッション失敗し続けるのを防ぐ。
+SKIP_MARKER="${HOME}/.jj-install-skip"
+COOLDOWN_SECONDS=86400  # 24時間
+
+if [ -f "$SKIP_MARKER" ]; then
+  marker_age=$(( $(date +%s) - $(date -r "$SKIP_MARKER" +%s 2>/dev/null || stat -c %Y "$SKIP_MARKER" 2>/dev/null || echo 0) ))
+  if [ "$marker_age" -lt "$COOLDOWN_SECONDS" ]; then
+    echo "jj のインストールは前回失敗しました（$(( marker_age / 60 ))分前）。24時間後に再試行します。"
+    echo "今すぐ再試行するには: rm $SKIP_MARKER"
+    exit 0
+  else
+    # クールダウン期間を過ぎたのでマーカーを削除して再試行
+    rm -f "$SKIP_MARKER"
+  fi
+fi
+
+# インストール失敗時にマーカーファイルを作成するヘルパー関数
+mark_install_failed() {
+  local reason="${1:-unknown}"
+  echo "$reason" > "$SKIP_MARKER"
+}
+
 # 2. mise 経由でインストールを試みる
 if command -v mise &>/dev/null; then
   echo "jj が見つかりません。mise 経由でインストールします..."
@@ -43,6 +67,7 @@ case "${OS}-${ARCH}" in
   *)
     echo "警告: サポートされていないプラットフォーム (${OS}-${ARCH})"
     echo "手動でインストールしてください: https://jj-vcs.github.io/jj/latest/install-and-setup/"
+    mark_install_failed "unsupported-platform: ${OS}-${ARCH}"
     exit 0
     ;;
 esac
@@ -64,6 +89,7 @@ fi
 if [ -z "$LATEST_TAG" ]; then
   echo "警告: 最新バージョンの取得に失敗しました"
   echo "手動でインストールしてください: https://jj-vcs.github.io/jj/latest/install-and-setup/"
+  mark_install_failed "version-fetch-failed"
   exit 0
 fi
 
@@ -84,6 +110,7 @@ else
   rm -rf "$TMPDIR"
   echo "警告: jj のダウンロードに失敗しました"
   echo "手動でインストールしてください: https://jj-vcs.github.io/jj/latest/install-and-setup/"
+  mark_install_failed "download-failed: ${DOWNLOAD_URL}"
 fi
 
 exit 0


### PR DESCRIPTION
## Summary
Enhanced the `ensure-jj.sh` hook script with a cooldown mechanism to prevent repeated installation attempts after failures, and improved error tracking throughout the installation process.

## Key Changes
- **Cooldown mechanism**: Added a 24-hour skip marker (`~/.jj-install-skip`) that prevents retrying jj installation after failures, reducing unnecessary network requests and error spam during every session start
- **Binary detection**: Added check for existing `$HOME/bin/jj` executable to avoid re-downloading when the binary is already present (important since SessionStart hooks run in fresh shells)
- **Error tracking**: Introduced `mark_install_failed()` helper function to record installation failures with descriptive reasons
- **Failure markers**: Added failure markers at three critical points:
  - Unsupported platform detection
  - Version fetch failures
  - Download failures
- **User guidance**: Added clear messages explaining the cooldown period and how to manually retry (`rm ~/.jj-install-skip`)

## Implementation Details
- Cooldown duration is set to 86400 seconds (24 hours) and can be easily adjusted
- The marker file stores the failure reason for debugging purposes
- Cooldown check uses portable date arithmetic compatible with both GNU and BSD date utilities
- Existing installation checks (command availability and binary existence) run before cooldown logic to avoid unnecessary file operations

https://claude.ai/code/session_01772aJ7qSHSe2KZPzYgGoDd