### PR TITLE
Fix diff stats calculation to use unified diff instead of line count

### DIFF
--- a/.changeset/fix-diff-stats-calculation.md
+++ b/.changeset/fix-diff-stats-calculation.md
@@ -1,0 +1,10 @@
+---
+"ziku": patch
+---
+
+fix: 差分行数の計算を unified diff ベースに修正
+
+push サマリーの行数表示が実際の変更量と大きくズレる問題を修正。
+"modified" ファイルで行数の差（local - template）を表示していたのを、
+unified diff の実際の変更行数に修正。
+また "added"/"deleted" で末尾改行による off-by-one エラーも修正。

--- a/packages/ziku/src/commands/push.ts
+++ b/packages/ziku/src/commands/push.ts
@@ -22,6 +22,7 @@ import {
   inputPrTitle,
   selectPushFiles,
 } from "../ui/prompts";
+import { calculateDiffStats, formatStats } from "../ui/diff-view";
 import { intro, log, logDiffSummary, outro, pc, withSpinner } from "../ui/renderer";
 import { detectDiff, getPushableFiles } from "../utils/diff";
 import { createPullRequest, getGitHubToken } from "../utils/github";
@@ -42,35 +43,17 @@ import { detectUntrackedFiles } from "../utils/untracked";
  * FileDiff の差分統計を "+N -M" 形式でフォーマットする。
  *
  * 背景: git push の出力に合わせ、変更行数を可視化する。
- * "modified" の場合は行数の差を表示（詳細な unified diff は ziku diff で確認可能）。
+ * calculateDiffStats に統一し、unified diff ベースで実際の変更行数を算出する。
+ * 以前は行数の差で計算していたため、実際の変更量と大きくズレる問題があった。
  */
 function formatFileStat(file: {
+  path: string;
   type: string;
   localContent?: string;
   templateContent?: string;
 }): string {
-  let additions = 0;
-  let deletions = 0;
-
-  if (file.type === "added" && file.localContent) {
-    additions = file.localContent.split("\n").length;
-  } else if (file.type === "deleted" && file.templateContent) {
-    deletions = file.templateContent.split("\n").length;
-  } else if (file.type === "modified") {
-    const local = file.localContent?.split("\n").length ?? 0;
-    const tmpl = file.templateContent?.split("\n").length ?? 0;
-    additions = Math.max(0, local - tmpl);
-    deletions = Math.max(0, tmpl - local);
-    if (additions === 0 && deletions === 0 && file.localContent !== file.templateContent) {
-      additions = 1;
-      deletions = 1;
-    }
-  }
-
-  const parts: string[] = [];
-  if (additions > 0) parts.push(pc.green(`+${additions}`));
-  if (deletions > 0) parts.push(pc.red(`-${deletions}`));
-  return parts.length > 0 ? parts.join(" ") : pc.dim("~");
+  const stats = calculateDiffStats(file as import("../modules/schemas").FileDiff);
+  return formatStats(stats);
 }
 
 /**

--- a/packages/ziku/src/ui/__tests__/diff-view.test.ts
+++ b/packages/ziku/src/ui/__tests__/diff-view.test.ts
@@ -34,6 +34,19 @@ describe("diff-view", () => {
       });
     });
 
+    it("should count lines for added files with trailing newline", () => {
+      const file: FileDiff = {
+        path: "a.ts",
+        type: "added",
+        localContent: "line1\nline2\nline3\n",
+      };
+      // 末尾改行があっても 3行（以前は split("\n").length で 4 を返していた）
+      expect(calculateDiffStats(file)).toEqual({
+        additions: 3,
+        deletions: 0,
+      });
+    });
+
     it("should count lines for deleted files", () => {
       const file: FileDiff = {
         path: "a.ts",
@@ -46,7 +59,19 @@ describe("diff-view", () => {
       });
     });
 
-    it("should compute stats for modified files", () => {
+    it("should count lines for deleted files with trailing newline", () => {
+      const file: FileDiff = {
+        path: "a.ts",
+        type: "deleted",
+        templateContent: "line1\nline2\n",
+      };
+      expect(calculateDiffStats(file)).toEqual({
+        additions: 0,
+        deletions: 2,
+      });
+    });
+
+    it("should compute stats for modified files using unified diff", () => {
       const file: FileDiff = {
         path: "a.ts",
         type: "modified",
@@ -55,6 +80,48 @@ describe("diff-view", () => {
       };
       const stats = calculateDiffStats(file);
       expect(stats.additions).toBeGreaterThan(0);
+    });
+
+    it("should count actual changed lines for modified files, not line count difference", () => {
+      // 200行のファイルが50行のテンプレートと比較される場合、
+      // 行数差（150）ではなく実際の変更行数を返すべき
+      const templateLines = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join("\n");
+      const localLines = Array.from({ length: 50 }, (_, i) => {
+        // 3行だけ変更
+        if (i === 5) return "modified line 6";
+        if (i === 10) return "modified line 11";
+        if (i === 20) return "modified line 21";
+        return `line ${i + 1}`;
+      }).join("\n");
+
+      const file: FileDiff = {
+        path: "big-file.ts",
+        type: "modified",
+        localContent: localLines,
+        templateContent: templateLines,
+      };
+      const stats = calculateDiffStats(file);
+      // 3行変更 → additions: 3, deletions: 3（各行の置換）
+      expect(stats.additions).toBe(3);
+      expect(stats.deletions).toBe(3);
+    });
+
+    it("should not show +150 for a file with 150 more lines but same content pattern", () => {
+      // ユーザーが報告したバグケース: formatFileStat が行数差で計算していた
+      const templateContent = '{\n  "name": "dev"\n}\n';
+      const localContent = '{\n  "name": "dev",\n  "settings": {\n    "key": "value"\n  }\n}\n';
+
+      const file: FileDiff = {
+        path: ".devcontainer/devcontainer.json",
+        type: "modified",
+        localContent,
+        templateContent,
+      };
+      const stats = calculateDiffStats(file);
+      // 行数差は 3 (6-3) だが、実際の変更行数で計算されるべき
+      // additions !== localLines - templateLines
+      expect(stats.additions).toBeLessThanOrEqual(5);
+      expect(stats.deletions).toBeLessThanOrEqual(5);
     });
 
     it("should handle undefined content for added", () => {
@@ -73,6 +140,43 @@ describe("diff-view", () => {
         path: "a.ts",
         type: "deleted",
       };
+      expect(calculateDiffStats(file)).toEqual({
+        additions: 0,
+        deletions: 0,
+      });
+    });
+
+    it("should handle single line content without newline", () => {
+      const file: FileDiff = {
+        path: "a.ts",
+        type: "added",
+        localContent: "single line",
+      };
+      expect(calculateDiffStats(file)).toEqual({
+        additions: 1,
+        deletions: 0,
+      });
+    });
+
+    it("should handle empty string content", () => {
+      const file: FileDiff = {
+        path: "a.ts",
+        type: "added",
+        localContent: "",
+      };
+      expect(calculateDiffStats(file)).toEqual({
+        additions: 0,
+        deletions: 0,
+      });
+    });
+
+    it("should handle content that is only a newline", () => {
+      const file: FileDiff = {
+        path: "a.ts",
+        type: "added",
+        localContent: "\n",
+      };
+      // "\n" は空行1つ → しかし実質的に空ファイル
       expect(calculateDiffStats(file)).toEqual({
         additions: 0,
         deletions: 0,

--- a/packages/ziku/src/ui/diff-view.ts
+++ b/packages/ziku/src/ui/diff-view.ts
@@ -22,6 +22,19 @@ export interface DiffStats {
   readonly deletions: number;
 }
 
+/**
+ * テキストの実際の行数をカウントする。
+ *
+ * 背景: `"a\nb\n".split("\n").length` は 3 を返すが、実際の行数は 2。
+ * 末尾の改行を除去してからカウントすることで正確な行数を得る。
+ */
+function countLines(content: string): number {
+  if (!content) return 0;
+  const normalized = content.endsWith("\n") ? content.slice(0, -1) : content;
+  if (normalized === "") return 0;
+  return normalized.split("\n").length;
+}
+
 /** ファイルの差分統計を計算 */
 export function calculateDiffStats(fileDiff: FileDiff): DiffStats {
   switch (fileDiff.type) {
@@ -30,11 +43,11 @@ export function calculateDiffStats(fileDiff: FileDiff): DiffStats {
     case "deleted":
       return {
         additions: 0,
-        deletions: fileDiff.templateContent?.split("\n").length ?? 0,
+        deletions: countLines(fileDiff.templateContent ?? ""),
       };
     case "added":
       return {
-        additions: fileDiff.localContent?.split("\n").length ?? 0,
+        additions: countLines(fileDiff.localContent ?? ""),
         deletions: 0,
       };
     case "modified": {


### PR DESCRIPTION
## Summary

Fixes a bug where the diff statistics displayed in push summaries were calculated incorrectly, especially for modified files. The calculation was based on the difference in line counts rather than actual changed lines, causing misleading statistics.

## Key Changes

- **Refactored `calculateDiffStats` function** in `diff-view.ts`:
  - Added `countLines()` helper to accurately count lines by handling trailing newlines correctly
  - Fixed "added" and "deleted" file stats to use the new `countLines()` function instead of `split("\n").length`
  - Unified diff calculation for "modified" files (implementation details in the full diff)

- **Updated `formatFileStat` function** in `push.ts`:
  - Replaced inline diff calculation logic with a call to `calculateDiffStats()`
  - Now uses `formatStats()` for consistent formatting across the codebase
  - Removed the problematic line-count-difference calculation that was causing inaccurate stats

- **Added comprehensive test coverage** in `diff-view.test.ts`:
  - Tests for trailing newline handling in added/deleted files
  - Tests for modified files with actual changed lines vs. line count differences
  - Edge cases: single line without newline, empty strings, content that is only a newline
  - Regression tests for the reported bug case

## Implementation Details

The core issue was that `"a\nb\n".split("\n").length` returns 3 (due to the empty string after the final newline), but the actual line count is 2. The new `countLines()` function normalizes by removing trailing newlines before splitting, providing accurate line counts.

For modified files, the calculation now uses unified diff analysis to count actual changed lines rather than computing `local_lines - template_lines`, which could be wildly inaccurate when files have different structures.

https://claude.ai/code/session_01LF1a2BE1bjN6UjnHehmtpp