### PR TITLE
refactor: modules.jsonc をモジュール形式に変換

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,4 @@ jobs:
         run: node --check packages/ziku-cli/bin.mjs
 
       - name: Validate modules.jsonc
-        run: |
-          node --input-type=module -e "
-            import { parse } from 'jsonc-parser';
-            import { readFileSync } from 'node:fs';
-            const text = readFileSync('.ziku/modules.jsonc', 'utf8');
-            const result = parse(text);
-            if (!result || typeof result !== 'object') throw new Error('Invalid JSON');
-            console.log('modules.jsonc is valid');
-          "
+        run: node scripts/validate-jsonc.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,35 +26,34 @@ jobs:
 
       - name: Validate modules.jsonc
         run: |
-          node -e "
-            const fs = require('fs');
-            const text = fs.readFileSync('.ziku/modules.jsonc', 'utf8');
-            // jsonc-parser がなくても JSONC をパースできる簡易実装。
-            // 文字列リテラル内の // や /* を誤除去しないよう、
-            // 文字列 → 保持、コメント → 除去 の順で処理する。
-            let result = '';
-            for (let i = 0; i < text.length; i++) {
-              if (text[i] === '\"') {
-                const start = i; i++;
-                while (i < text.length && text[i] !== '\"') { if (text[i] === '\\\\') i++; i++; }
-                i++;
-                result += text.slice(start, i);
-                continue;
-              }
-              if (text[i] === '/' && text[i+1] === '/') {
-                while (i < text.length && text[i] !== '\n') i++;
-                continue;
-              }
-              if (text[i] === '/' && text[i+1] === '*') {
-                i += 2;
-                while (i < text.length && !(text[i] === '*' && text[i+1] === '/')) i++;
-                i += 2;
-                continue;
-              }
-              result += text[i];
+          node <<'SCRIPT'
+          const fs = require("fs");
+          const text = fs.readFileSync(".ziku/modules.jsonc", "utf8");
+          // JSONC → JSON 変換。文字列リテラル内の // や /* を誤除去しないよう、
+          // 文字列 → 保持、コメント → 除去 の順で処理する。
+          let result = "";
+          for (let i = 0; i < text.length; i++) {
+            if (text[i] === '"') {
+              const start = i; i++;
+              while (i < text.length && text[i] !== '"') { if (text[i] === "\\") i++; i++; }
+              i++;
+              result += text.slice(start, i);
+              continue;
             }
-            // Strip trailing commas
-            result = result.replace(/,\s*([\]}])/g, '\$1');
-            JSON.parse(result);
-            console.log('modules.jsonc is valid');
-          "
+            if (text[i] === "/" && text[i+1] === "/") {
+              while (i < text.length && text[i] !== "\n") i++;
+              continue;
+            }
+            if (text[i] === "/" && text[i+1] === "*") {
+              i += 2;
+              while (i < text.length && !(text[i] === "*" && text[i+1] === "/")) i++;
+              i += 2;
+              continue;
+            }
+            result += text[i];
+          }
+          // trailing comma 除去
+          result = result.replace(/,\s*([\]}])/g, "$1");
+          JSON.parse(result);
+          console.log("modules.jsonc is valid");
+          SCRIPT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,33 @@ jobs:
         run: |
           node -e "
             const fs = require('fs');
-            let text = fs.readFileSync('.ziku/modules.jsonc', 'utf8');
-            // Strip single-line comments and multi-line comments
-            text = text.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+            const text = fs.readFileSync('.ziku/modules.jsonc', 'utf8');
+            // jsonc-parser がなくても JSONC をパースできる簡易実装。
+            // 文字列リテラル内の // や /* を誤除去しないよう、
+            // 文字列 → 保持、コメント → 除去 の順で処理する。
+            let result = '';
+            for (let i = 0; i < text.length; i++) {
+              if (text[i] === '\"') {
+                const start = i; i++;
+                while (i < text.length && text[i] !== '\"') { if (text[i] === '\\\\') i++; i++; }
+                i++;
+                result += text.slice(start, i);
+                continue;
+              }
+              if (text[i] === '/' && text[i+1] === '/') {
+                while (i < text.length && text[i] !== '\n') i++;
+                continue;
+              }
+              if (text[i] === '/' && text[i+1] === '*') {
+                i += 2;
+                while (i < text.length && !(text[i] === '*' && text[i+1] === '/')) i++;
+                i += 2;
+                continue;
+              }
+              result += text[i];
+            }
             // Strip trailing commas
-            text = text.replace(/,\s*([\]}])/g, '\$1');
-            JSON.parse(text);
+            result = result.replace(/,\s*([\]}])/g, '\$1');
+            JSON.parse(result);
             console.log('modules.jsonc is valid');
           "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
 
       - name: Validate modules.jsonc
         run: |
-          node -e "
-            const { parse } = require('jsonc-parser');
-            const fs = require('fs');
-            const text = fs.readFileSync('.ziku/modules.jsonc', 'utf8');
+          node --input-type=module -e "
+            import { parse } from 'jsonc-parser';
+            import { readFileSync } from 'node:fs';
+            const text = readFileSync('.ziku/modules.jsonc', 'utf8');
             const result = parse(text);
             if (!result || typeof result !== 'object') throw new Error('Invalid JSON');
             console.log('modules.jsonc is valid');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,34 +26,11 @@ jobs:
 
       - name: Validate modules.jsonc
         run: |
-          node <<'SCRIPT'
-          const fs = require("fs");
-          const text = fs.readFileSync(".ziku/modules.jsonc", "utf8");
-          // JSONC → JSON 変換。文字列リテラル内の // や /* を誤除去しないよう、
-          // 文字列 → 保持、コメント → 除去 の順で処理する。
-          let result = "";
-          for (let i = 0; i < text.length; i++) {
-            if (text[i] === '"') {
-              const start = i; i++;
-              while (i < text.length && text[i] !== '"') { if (text[i] === "\\") i++; i++; }
-              i++;
-              result += text.slice(start, i);
-              continue;
-            }
-            if (text[i] === "/" && text[i+1] === "/") {
-              while (i < text.length && text[i] !== "\n") i++;
-              continue;
-            }
-            if (text[i] === "/" && text[i+1] === "*") {
-              i += 2;
-              while (i < text.length && !(text[i] === "*" && text[i+1] === "/")) i++;
-              i += 2;
-              continue;
-            }
-            result += text[i];
-          }
-          // trailing comma 除去
-          result = result.replace(/,\s*([\]}])/g, "$1");
-          JSON.parse(result);
-          console.log("modules.jsonc is valid");
-          SCRIPT
+          node -e "
+            const { parse } = require('jsonc-parser');
+            const fs = require('fs');
+            const text = fs.readFileSync('.ziku/modules.jsonc', 'utf8');
+            const result = parse(text);
+            if (!result || typeof result !== 'object') throw new Error('Invalid JSON');
+            console.log('modules.jsonc is valid');
+          "

--- a/.ziku/modules.jsonc
+++ b/.ziku/modules.jsonc
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/tktcorporation/ziku/main/schema/modules.json",
   "modules": [
     {
       "name": "Root",

--- a/.ziku/modules.jsonc
+++ b/.ziku/modules.jsonc
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://raw.githubusercontent.com/tktcorporation/ziku/main/schema/modules.json",
   "modules": [
     {
       "name": "Root",

--- a/.ziku/modules.jsonc
+++ b/.ziku/modules.jsonc
@@ -1,27 +1,49 @@
 {
-  "include": [
-    ".mcp.json",
-    ".mise.toml",
-    ".devcontainer/devcontainer.json",
-    ".devcontainer/.gitignore",
-    ".devcontainer/setup-*.sh",
-    ".devcontainer/test-*.sh",
-    ".devcontainer/.env.devcontainer.example",
-    ".devcontainer/run-chrome-devtools-mcp.sh",
-    ".github/workflows/issue-link.yml",
-    ".github/workflows/label.yml",
-    ".github/labeler.yml",
-    ".claude/settings.json",
-    ".claude/hooks/*.sh",
-    ".claude/rules/*.md",
-    ".claude/rules/jujutsu.md",
-    ".claude/skills/upstream-fix/SKILL.md",
-    ".claude/skills/ui-craft",
-    ".claude/skills/ui-design-research",
-    ".claude/skills/faithful-doc-writing",
-    ".claude/skills/autonomous-dev/SKILL.md",
-    ".claude/hookify.block-blind-kill.local.md",
-    ".claude/hookify.block-revert-others.local.md",
-    ".claude/rules/parallel-work.md"
+  "$schema": "https://raw.githubusercontent.com/tktcorporation/ziku/main/schema/modules.json",
+  "modules": [
+    {
+      "name": "Root",
+      "description": "Editor and tooling configuration",
+      "include": [".mcp.json", ".mise.toml"]
+    },
+    {
+      "name": "DevContainer",
+      "description": "VS Code DevContainer configuration",
+      "include": [
+        ".devcontainer/devcontainer.json",
+        ".devcontainer/.gitignore",
+        ".devcontainer/setup-*.sh",
+        ".devcontainer/test-*.sh",
+        ".devcontainer/.env.devcontainer.example",
+        ".devcontainer/run-chrome-devtools-mcp.sh"
+      ]
+    },
+    {
+      "name": "GitHub",
+      "description": "GitHub Actions workflows and repository settings",
+      "include": [
+        ".github/workflows/issue-link.yml",
+        ".github/workflows/label.yml",
+        ".github/labeler.yml"
+      ]
+    },
+    {
+      "name": "Claude",
+      "description": "Claude Code rules, hooks, and skills",
+      "include": [
+        ".claude/settings.json",
+        ".claude/hooks/*.sh",
+        ".claude/rules/*.md",
+        ".claude/rules/jujutsu.md",
+        ".claude/rules/parallel-work.md",
+        ".claude/skills/upstream-fix/SKILL.md",
+        ".claude/skills/ui-craft",
+        ".claude/skills/ui-design-research",
+        ".claude/skills/faithful-doc-writing",
+        ".claude/skills/autonomous-dev/SKILL.md",
+        ".claude/hookify.block-blind-kill.local.md",
+        ".claude/hookify.block-revert-others.local.md"
+      ]
+    }
   ]
 }

--- a/scripts/validate-jsonc.mjs
+++ b/scripts/validate-jsonc.mjs
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+
+const text = readFileSync(".ziku/modules.jsonc", "utf8");
+
+// JSONC → JSON 変換（Node.js ビルトインのみ使用）
+// 文字列リテラル内の // や /* を誤除去しないよう状態管理する
+let result = "";
+let inString = false;
+let i = 0;
+while (i < text.length) {
+  if (inString) {
+    if (text[i] === "\\") {
+      result += text[i] + text[i + 1];
+      i += 2;
+      continue;
+    }
+    if (text[i] === '"') {
+      inString = false;
+    }
+    result += text[i];
+    i++;
+    continue;
+  }
+  // 文字列開始
+  if (text[i] === '"') {
+    inString = true;
+    result += text[i];
+    i++;
+    continue;
+  }
+  // 行コメント
+  if (text[i] === "/" && text[i + 1] === "/") {
+    while (i < text.length && text[i] !== "\n") i++;
+    continue;
+  }
+  // ブロックコメント
+  if (text[i] === "/" && text[i + 1] === "*") {
+    i += 2;
+    while (i < text.length && !(text[i] === "*" && text[i + 1] === "/")) i++;
+    i += 2;
+    continue;
+  }
+  result += text[i];
+  i++;
+}
+
+// trailing comma 除去
+result = result.replace(/,\s*([\]}])/g, "$1");
+
+JSON.parse(result);
+console.log("modules.jsonc is valid");


### PR DESCRIPTION
## Summary

- `.ziku/modules.jsonc` をフラット形式からモジュール形式に変換
- パターンを4つのモジュール（Root, DevContainer, GitHub, Claude）にグループ化

## Background

ziku 本体で modules.jsonc を常にモジュール形式に統一する変更を行っている（tktcorporation/ziku#31）。テンプレートリポジトリ側もモジュール形式に合わせる。

モジュール形式にすることで `ziku init` 時にモジュール選択UIが表示され、必要なモジュールだけを選択できるようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)