### PR TITLE
chore: pr-first-reader-check スキルを ziku include に追加

### DIFF
--- a/.ziku/ziku.jsonc
+++ b/.ziku/ziku.jsonc
@@ -20,6 +20,7 @@
     ".claude/skills/ui-design-research",
     ".claude/skills/faithful-doc-writing",
     ".claude/skills/autonomous-dev/SKILL.md",
+    ".claude/skills/pr-first-reader-check",
     ".claude/hookify.block-blind-kill.local.md",
     ".claude/hookify.block-revert-others.local.md"
   ]


### PR DESCRIPTION
## 概要

`.ziku/ziku.jsonc` の `include` から漏れていた `.claude/skills/pr-first-reader-check` を追加しました。

## 変更内容

- `include` リストに `.claude/skills/pr-first-reader-check` を追加

## 補足

- 同様に未登録の `pr-impact-review` は、依頼により今回は対象外としています。

https://claude.ai/code/session_01Vhw6GMzzwnEtVHHzAnCT9k

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vhw6GMzzwnEtVHHzAnCT9k)_